### PR TITLE
Update the affected operating systems for SyncAppvPublishingServer

### DIFF
--- a/yml/OSBinaries/Syncappvpublishingserver.yml
+++ b/yml/OSBinaries/Syncappvpublishingserver.yml
@@ -11,7 +11,7 @@ Commands:
     Privileges: User
     MitreID: T1218
     MitreLink: https://attack.mitre.org/wiki/Technique/T1218
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
+    OperatingSystem: Windows 10 1709, Windows 10 1703, Windows 10 1607
 Full_Path:
   - Path: C:\Windows\System32\SyncAppvPublishingServer.exe
   - Path: C:\Windows\SysWOW64\SyncAppvPublishingServer.exe


### PR DESCRIPTION
This updates the affected operating systems for the `SyncAppvPublishingServer` technique. The affected binary is not available on Windows 7 or 8.1 (I admittedly didn't test 8). The technique also appears to have been patched in Windows 10 build 1803. I explicitly tested the original disclosure command `SyncAppvPublishingServer "n;Get-Host | Out-File here.txt"` on builds 1607 and 1709 where I was able to confirm it was working.