### PR TITLE
Fix a typo in Findstr.yml

### DIFF
--- a/yml/OSBinaries/Findstr.yml
+++ b/yml/OSBinaries/Findstr.yml
@@ -42,7 +42,7 @@ Full_Path:
 Code_Sample: 
 - Code:
 Detection:
- - IOC: finstr.exe should normally not be invoked on a client system
+ - IOC: findstr.exe should normally not be invoked on a client system
 Resources:
   - Link: https://oddvar.moe/2018/04/11/putting-data-in-alternate-data-streams-and-how-to-execute-it-part-2/
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f


### PR DESCRIPTION
`finstr.exe` should be `findstr.exe`