### PR TITLE
Add lolbin for fltMC.exe

### DIFF
--- a/yml/OSBinaries/fltMC.yml
+++ b/yml/OSBinaries/fltMC.yml
@@ -1,0 +1,26 @@
+---
+Name: fltMC.exe
+Description: Filter Manager Control Program used by Windows
+Author: 'John Lambert'
+Created: '2021-09-18'
+Commands:
+  - Command: fltMC.exe unload SysmonDrv
+    Description: Unloads a driver used by security agents
+    Usecase: Defense evasion
+    Category: ADS 
+    Privileges: Admin
+    MitreID: T1562
+    MitreLink: https://attack.mitre.org/techniques/T1562/002/
+    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
+Full_Path:
+  - Path: C:\Windows\System32\fltMC.exe
+Code_Sample: 
+- Code:
+Detection:
+ - IOC: 4688 events with fltMC.exe
+Resources:
+  - Link: https://www.darkoperator.com/blog/2018/10/5/operating-offensively-against-sysmon
+Acknowledgement:
+  - Person: Carlos Perez
+    Handle: '@Carlos_Perez'
+---


### PR DESCRIPTION
Used by redteams for defense evasion to disable drivers used by agents like sysmon

https://www.darkoperator.com/blog/2018/10/5/operating-offensively-against-sysmon
https://github.com/oddcod3/Phantom-Evasion/blob/master/Modules/post-exploitation/Postex_CMD_UnloadSysmonDriver_windows.py