### PR TITLE
Defensive - Detection Content Additions for LOLBINs

### DIFF
--- a/yml/OSBinaries/AppInstaller.yml
+++ b/yml/OSBinaries/AppInstaller.yml
@@ -13,6 +13,8 @@ Commands:
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.11.2521.0_x64__8wekyb3d8bbwe\AppInstaller.exe
+Detection:
+  - Sigma:
 Resources:
   - Link: https://twitter.com/notwhickey/status/1333900137232523264
 Acknowledgement:

--- a/yml/OSBinaries/Aspnet_Compiler.yml
+++ b/yml/OSBinaries/Aspnet_Compiler.yml
@@ -17,7 +17,8 @@ Full_Path:
 Code_Sample:
   - Code: https://github.com/ThunderGunExpress/BringYourOwnBuilder
 Detection:
-  - IOC: Sysmon Event ID 1 - Process Creation
+  - Sigma:
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://ijustwannared.team/2020/08/01/the-curious-case-of-aspnet_compiler-exe/
   - Link: https://docs.microsoft.com/en-us/dotnet/api/system.web.compilation.buildprovider.generatecode?view=netframework-4.8

--- a/yml/OSBinaries/At.yml
+++ b/yml/OSBinaries/At.yml
@@ -15,8 +15,9 @@ Full_Path:
   - Path: C:\WINDOWS\System32\At.exe
   - Path: C:\WINDOWS\SysWOW64\At.exe
 Detection:
-  - IOC: Scheduled task is created
-  - IOC: Windows event log - type 3 login
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_interactive_at.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/network/zeek/zeek_smb_converted_win_atsvc_task.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/builtin/win_atsvc_task.yml
   - IOC: C:\Windows\System32\Tasks\At1 (substitute 1 with subsequent number of at job)
   - IOC: C:\Windows\Tasks\At1.job
   - IOC: Registry Key - Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\At1.

--- a/yml/OSBinaries/Atbroker.yml
+++ b/yml/OSBinaries/Atbroker.yml
@@ -17,6 +17,8 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/eb406ba36fc607986970c09e53058af412093647/rules/windows/process_creation/win_susp_atbroker.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/registry_event/sysmon_susp_atbroker_change.yml
  - IOC: Changes to HKCU\Software\Microsoft\Windows NT\CurrentVersion\Accessibility\Configuration
  - IOC: Changes to HKLM\Software\Microsoft\Windows NT\CurrentVersion\Accessibility\ATs
  - IOC: Unknown AT starting C:\Windows\System32\ATBroker.exe /start malware

--- a/yml/OSBinaries/Bash.yml
+++ b/yml/OSBinaries/Bash.yml
@@ -38,6 +38,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: 
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: Child process from bash.exe
 Resources:
   - Link: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules

--- a/yml/OSBinaries/Bitsadmin.yml
+++ b/yml/OSBinaries/Bitsadmin.yml
@@ -38,6 +38,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/90ca1a8ad2e5c96d09a9ae4ff92483a2110d49ff/rules/windows/process_creation/win_process_creation_bitsadmin_download.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/abcaf00aeef3769aa2a6f66f7fb6537b867c1691/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/e40b8592544721c689f8ae96477ea1218e4c7a05/rules/windows/process_creation/win_monitoring_for_persistence_via_bits.yml
   - IOC: Child process from bitsadmin.exe
   - IOC: bitsadmin creates new files
   - IOC: bitsadmin adds data to alternate data stream

--- a/yml/OSBinaries/Certoc.yml
+++ b/yml/OSBinaries/Certoc.yml
@@ -24,6 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/406f10b583469f7f7c245ff41002f75902693b7d/rules/windows/process_creation/process_creation_certoc_execution.yml
   - IOC: Process creation with given parameter
   - IOC: Unsigned DLL load via certoc.exe
   - IOC: Network connection via certoc.exe

--- a/yml/OSBinaries/Certreq.yml
+++ b/yml/OSBinaries/Certreq.yml
@@ -24,6 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma:
   - IOC: certreq creates new files
   - IOC: certreq makes POST requests
 Resources:

--- a/yml/OSBinaries/Certutil.yml
+++ b/yml/OSBinaries/Certutil.yml
@@ -52,6 +52,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/0fcbce993288f993e626494a50dad15fc26c8a0c/rules/windows/process_creation/win_susp_certutil_command.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_certutil_encode.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/e9260679d4aeae7f696001c5b14d318d31c8f076/rules/windows/process_creation/process_creation_root_certificate_installed.yml
   - IOC: Certutil.exe creating new files on disk
   - IOC: Useragent Microsoft-CryptoAPI/10.0
   - IOC: Useragent CertUtil URL Agent

--- a/yml/OSBinaries/Cmd.yml
+++ b/yml/OSBinaries/Cmd.yml
@@ -24,6 +24,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
+ - Sigma: 
  - IOC: cmd.exe executing files from alternate data streams.
 Resources:
   - Link: https://twitter.com/yeyint_mth/status/1143824979139579904

--- a/yml/OSBinaries/Cmdkey.yml
+++ b/yml/OSBinaries/Cmdkey.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC: Usage of this command could be an IOC
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/c3c152d457773454f67895008a1abde823be0755/rules/windows/process_creation/win_cmdkey_recon.yml
 Resources:
   - Link: https://www.peew.pw/blog/2017/11/26/exploring-cmdkey-an-edge-case-for-privilege-escalation
   - Link: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmdkey

--- a/yml/OSBinaries/Cmdl32.yml
+++ b/yml/OSBinaries/Cmdl32.yml
@@ -15,6 +15,7 @@ Full_Path:
   - Path: C:\Windows\System32\cmdl32.exe
   - Path: C:\Windows\SysWOW64\cmdl32.exe
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/3416db73016f25ce115f5597fe74320d2428db66/rules/windows/process_creation/win_pc_susp_cmdl32_lolbas.yml
   - IOC: Reports of downloading from suspicious URLs in %TMP%\config.log
   - IOC: Useragent Microsoft(R) Connection Manager Vpn File Update
 Resources:

--- a/yml/OSBinaries/Cmstp.yml
+++ b/yml/OSBinaries/Cmstp.yml
@@ -22,10 +22,11 @@ Full_Path:
   - Path: C:\Windows\System32\cmstp.exe
   - Path: C:\Windows\SysWOW64\cmstp.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Execution of cmstp.exe should not be normal unless VPN is in use
- - IOC: Cmstp.exe communication towards internet and getting files
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/6d0d58dfe240f7ef46e7da928c0b65223a46c3b2/rules/windows/process_creation/sysmon_cmstp_execution_by_creation.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_uac_cmstp.yml
+ - IOC: Execution of cmstp.exe without a VPN use case is suspicious
 Resources:
   - Link: https://twitter.com/NickTyrer/status/958450014111633408
   - Link: https://gist.github.com/NickTyrer/bbd10d20a5bb78f64a9d13f399ea0f80

--- a/yml/OSBinaries/ConfigSecurityPolicy.yml
+++ b/yml/OSBinaries/ConfigSecurityPolicy.yml
@@ -16,6 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma:
   - IOC: ConfigSecurityPolicy storing data into alternate data streams.
   - IOC: Preventing/Detecting ConfigSecurityPolicy with non-RFC1918 addresses by Network IPS/IDS.
   - IOC: Monitor process creation for non-SYSTEM and non-LOCAL SERVICE accounts launching ConfigSecurityPolicy.exe.

--- a/yml/OSBinaries/Control.yml
+++ b/yml/OSBinaries/Control.yml
@@ -17,7 +17,10 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/e8b633f54fce88e82b1c3d5e7c7bfa7d3d0beee7/rules/windows/process_creation/win_susp_control_cve_2021_40444.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_control_dll_load.yml
  - IOC: Control.exe executing files from alternate data streams.
+ - IOC: Control.exe executing library file without cpl extension 
 Resources:
   - Link: https://pentestlab.blog/2017/05/24/applocker-bypass-control-panel/
   - Link: https://www.contextis.com/resources/blog/applocker-bypass-registry-key-manipulation/

--- a/yml/OSBinaries/Csc.yml
+++ b/yml/OSBinaries/Csc.yml
@@ -24,7 +24,10 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC: Csc.exe should normally not run a system unless it is used for development.
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_csc.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_csc_folder.yml
+ - 
+ - IOC: Csc.exe should normally not run as System account unless it is used for development.
 Resources:
   - Link: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/command-line-building-with-csc-exe
 Acknowledgement:

--- a/yml/OSBinaries/Csc.yml
+++ b/yml/OSBinaries/Csc.yml
@@ -26,7 +26,6 @@ Code_Sample:
 Detection:
  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_csc.yml
  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_csc_folder.yml
- - 
  - IOC: Csc.exe should normally not run as System account unless it is used for development.
 Resources:
   - Link: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/command-line-building-with-csc-exe

--- a/yml/OSBinaries/Cscript.yml
+++ b/yml/OSBinaries/Cscript.yml
@@ -15,7 +15,7 @@ Full_Path:
   - Path: C:\Windows\System32\cscript.exe
   - Path: C:\Windows\SysWOW64\cscript.exe
 Code_Sample:
-- Code:
+ - Code:
 Detection:
  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_script_execution.yml
  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml

--- a/yml/OSBinaries/Cscript.yml
+++ b/yml/OSBinaries/Cscript.yml
@@ -17,7 +17,12 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_script_execution.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
+ - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
  - IOC: Cscript.exe executing files from alternate data streams
+ - IOC: DotNet CLR libraries loaded into Cscript.exe
+ - IOF: DotNet CLR Usage Log - Cscript.exe.log
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
   - Link: https://oddvar.moe/2018/01/14/putting-data-in-alternate-data-streams-and-how-to-execute-it/

--- a/yml/OSBinaries/Cscript.yml
+++ b/yml/OSBinaries/Cscript.yml
@@ -21,8 +21,8 @@ Detection:
  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
  - IOC: Cscript.exe executing files from alternate data streams
- - IOC: DotNet CLR libraries loaded into Cscript.exe
- - IOF: DotNet CLR Usage Log - Cscript.exe.log
+ - IOC: DotNet CLR libraries loaded into cscript.exe
+ - IOC: DotNet CLR Usage Log - cscript.exe.log
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
   - Link: https://oddvar.moe/2018/01/14/putting-data-in-alternate-data-streams-and-how-to-execute-it/

--- a/yml/OSBinaries/DataSvcUtil.yml
+++ b/yml/OSBinaries/DataSvcUtil.yml
@@ -16,6 +16,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.github.com/teixeira0xfffff/837e5bfed0d1b0a29a7cb1e5dbdd9ca6
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/dc030e0128a38510b0a866e1210f5ebd7c418c0b/rules/windows/process_creation/process_creation_lolbas_data_exfiltration_by_using_datasvcutil.yml
   - IOC: The DataSvcUtil.exe tool is installed in the .NET Framework directory.
   - IOC: Preventing/Detecting DataSvcUtil with non-RFC1918 addresses by Network IPS/IDS.
   - IOC: Monitor process creation for non-SYSTEM and non-LOCAL SERVICE accounts launching DataSvcUtil.

--- a/yml/OSBinaries/Desktopimgdownldr.yml
+++ b/yml/OSBinaries/Desktopimgdownldr.yml
@@ -16,6 +16,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_desktopimgdownldr.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/win_susp_desktopimgdownldr_file.yml
   - IOC: desktopimgdownldr.exe that creates non-image file
   - IOC: Change of HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\PersonalizationCSP\LockScreenImageUrl
 Resources:

--- a/yml/OSBinaries/Dfsvc.yml
+++ b/yml/OSBinaries/Dfsvc.yml
@@ -5,7 +5,7 @@ Author: 'Oddvar Moe'
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe dfshim.dll,ShOpenVerbApplication http://www.domain.com/application/?param1=foo
-    Description: Executes click-once-application from Url
+    Description: Executes click-once-application from Url (trampoline for Dfsvc.exe, DotNet ClickOnce host)
     Usecase: Use binary to bypass Application whitelisting
     Category: AWL bypass
     Privileges: User
@@ -19,7 +19,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://github.com/api0cradle/ShmooCon-2015/blob/master/ShmooCon-2015-Simple-WLEvasion.pdf
   - Link: https://stackoverflow.com/questions/13312273/clickonce-runtime-dfsvc-exe

--- a/yml/OSBinaries/Diantz.yml
+++ b/yml/OSBinaries/Diantz.yml
@@ -24,6 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma:
   - IOC: diantz storing data into alternate data streams.
   - IOC: diantz getting a file from a remote machine or the internet.
 Resources:

--- a/yml/OSBinaries/Diskshadow.yml
+++ b/yml/OSBinaries/Diskshadow.yml
@@ -24,8 +24,9 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/b4d5b44ea86cda24f38a87d3b0c5f9d4455bf841/rules/windows/process_creation/win_susp_diskshadow.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/b3df5bf325461df9bcfeb051895b0c8dc3258234/rules/windows/process_creation/win_shadow_copies_deletion.yml
  - IOC: Child process from diskshadow.exe
- - IOC: Diskshadow reading input from file
 Resources:
   - Link: https://bohops.com/2018/03/26/diskshadow-the-return-of-vss-evasion-persistence-and-active-directory-database-extraction/
 Acknowledgement:

--- a/yml/OSBinaries/Dllhost.yml
+++ b/yml/OSBinaries/Dllhost.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
 Resources:
   - Link: https://twitter.com/CyberRaiju/status/1167415118847598594
   - Link: https://nasbench.medium.com/what-is-the-dllhost-exe-process-actually-running-ef9fe4c19c08

--- a/yml/OSBinaries/Dnscmd.yml
+++ b/yml/OSBinaries/Dnscmd.yml
@@ -17,7 +17,8 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC: Dnscmd.exe loading dll from UNC path
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/b08b3e2b0d5111c637dbede1381b07cb79f8c2eb/rules/windows/process_creation/process_creation_dns_serverlevelplugindll.yml
+ - IOC: Dnscmd.exe loading dll from UNC/arbitrary path
 Resources:
   - Link: https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83
   - Link: https://blog.3or.de/hunting-dns-server-level-plugin-dll-injection.html

--- a/yml/OSBinaries/Esentutl.yml
+++ b/yml/OSBinaries/Esentutl.yml
@@ -52,7 +52,10 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/fb750721b25ec4573acc32a0822d047a8ecdf269/rules/windows/deprecated/win_susp_vssadmin_ntds_activity.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/fb750721b25ec4573acc32a0822d047a8ecdf269/rules/windows/deprecated/win_susp_esentutl_activity.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/bacb44ab972343358bae612e4625f8ba2e043573/rules/windows/process_creation/process_susp_esentutl_params.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_copying_sensitive_files_with_credential_data.yml
 Resources:
   - Link: https://twitter.com/egre55/status/985994639202283520
   - Link: https://dfironthemountain.wordpress.com/2018/12/06/locked-file-access-using-esentutl-exe/

--- a/yml/OSBinaries/Eventvwr.yml
+++ b/yml/OSBinaries/Eventvwr.yml
@@ -17,8 +17,10 @@ Full_Path:
 Code_Sample:
   - Code: https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-EventVwrBypass.ps1
 Detection:
- - IOC: eventvwr.exe launching child process other than mmc.exe
- - IOC: Creation or modification of the registry value HKCU\Software\Classes\mscfile\shell\open\command
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/b08b3e2b0d5111c637dbede1381b07cb79f8c2eb/rules/windows/process_creation/process_creation_sysmon_uac_bypass_eventvwr.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/b08b3e2b0d5111c637dbede1381b07cb79f8c2eb/rules/windows/registry_event/registry_event_uac_bypass_eventvwr.yml
+  - IOC: eventvwr.exe launching child process other than mmc.exe
+  - IOC: Creation or modification of the registry value HKCU\Software\Classes\mscfile\shell\open\command
 Resources:
   - Link: https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/
   - Link: https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-EventVwrBypass.ps1

--- a/yml/OSBinaries/Expand.yml
+++ b/yml/OSBinaries/Expand.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/b25fbbea54014565fc4551f94c97c0d7550b1c04/rules/windows/process_creation/sysmon_expand_cabinet_files.yml
 Resources:
   - Link: https://twitter.com/infosecn1nja/status/986628482858807297
   - Link: https://twitter.com/Oddvarmoe/status/986709068759949319

--- a/yml/OSBinaries/Explorer.yml
+++ b/yml/OSBinaries/Explorer.yml
@@ -22,9 +22,11 @@ Full_Path:
   - Path: C:\Windows\explorer.exe
   - Path: C:\Windows\SysWOW64\explorer.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Multiple instances of explorer.exe or explorer.exe using the /root command line can help to detect this.
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_explorer_break_proctree.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_explorer.yml
+  - IOC: Multiple instances of explorer.exe or explorer.exe using the /root command line is suspicious.
 Resources:
   - Link: https://twitter.com/CyberRaiju/status/1273597319322058752?s=20
   - Link: https://twitter.com/bohops/status/1276356245541335048

--- a/yml/OSBinaries/Extexport.yml
+++ b/yml/OSBinaries/Extexport.yml
@@ -15,9 +15,10 @@ Full_Path:
   - Path: C:\Program Files\Internet Explorer\Extexport.exe
   - Path: C:\Program Files (x86)\Internet Explorer\Extexport.exe
 Code_Sample:
-- Code:
+ - Code:
 Detection:
- - IOC: Extexport.exe loads dll and is execute from other folder the original path
+  - Sigma:
+  - IOC: Extexport.exe loads dll and is execute from other folder the original path
 Resources:
   - Link: http://www.hexacorn.com/blog/2018/04/24/extexport-yet-another-lolbin/
 Acknowledgement:

--- a/yml/OSBinaries/Extrac32.yml
+++ b/yml/OSBinaries/Extrac32.yml
@@ -36,9 +36,9 @@ Full_Path:
   - Path: C:\Windows\System32\extrac32.exe
   - Path: C:\Windows\SysWOW64\extrac32.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+ - Sigma:
 Resources:
   - Link: https://oddvar.moe/2018/04/11/putting-data-in-alternate-data-streams-and-how-to-execute-it-part-2/
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Findstr.yml
+++ b/yml/OSBinaries/Findstr.yml
@@ -4,15 +4,15 @@ Description:
 Author: 'Oddvar Moe'
 Created: 2018-05-25
 Commands:
-  - Command: findstr /V /L W3AllLov3DonaldTrump c:\ADS\file.exe > c:\ADS\file.txt:file.exe
-    Description: Searches for the string W3AllLov3DonaldTrump, since it does not exist (/V) file.exe is written to an Alternate Data Stream (ADS) of the file.txt file.
+  - Command: findstr /V /L W3AllLov3LolBas c:\ADS\file.exe > c:\ADS\file.txt:file.exe
+    Description: Searches for the string W3AllLov3LolBas, since it does not exist (/V) file.exe is written to an Alternate Data Stream (ADS) of the file.txt file.
     Usecase: Add a file to an alternate data stream to hide from defensive counter measures
     Category: ADS
     Privileges: User
     MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
-  - Command: findstr /V /L W3AllLov3DonaldTrump \\webdavserver\folder\file.exe > c:\ADS\file.txt:file.exe
-    Description: Searches for the string W3AllLov3DonaldTrump, since it does not exist (/V) file.exe is written to an Alternate Data Stream (ADS) of the file.txt file.
+  - Command: findstr /V /L W3AllLov3LolBas \\webdavserver\folder\file.exe > c:\ADS\file.txt:file.exe
+    Description: Searches for the string W3AllLov3LolBas, since it does not exist (/V) file.exe is written to an Alternate Data Stream (ADS) of the file.txt file.
     Usecase: Add a file to an alternate data stream from a webdav server to hide from defensive counter measures
     Category: ADS
     Privileges: User
@@ -25,8 +25,8 @@ Commands:
     Privileges: User
     MitreID: T1552.001
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
-  - Command: findstr /V /L W3AllLov3DonaldTrump \\webdavserver\folder\file.exe > c:\ADS\file.exe
-    Description: Searches for the string W3AllLov3DonaldTrump, since it does not exist (/V) file.exe is downloaded to the target file.
+  - Command: findstr /V /L W3AllLov3LolBas \\webdavserver\folder\file.exe > c:\ADS\file.exe
+    Description: Searches for the string W3AllLov3LolBas, since it does not exist (/V) file.exe is downloaded to the target file.
     Usecase: Download/Copy file from webdav server
     Category: Download
     Privileges: User
@@ -38,7 +38,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC: findstr.exe should normally not be invoked on a client system
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_findstr.yml
 Resources:
   - Link: https://oddvar.moe/2018/04/11/putting-data-in-alternate-data-streams-and-how-to-execute-it-part-2/
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Finger.yml
+++ b/yml/OSBinaries/Finger.yml
@@ -15,6 +15,7 @@ Full_Path:
   - Path: c:\windows\system32\finger.exe
   - Path: c:\windows\syswow64\finger.exe
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_finger_usage.yml
   - IOC: finger.exe should not be run on a normal workstation.
   - IOC: finger.exe connecting to external resources.
 Resources:

--- a/yml/OSBinaries/FltMC.yml
+++ b/yml/OSBinaries/FltMC.yml
@@ -14,9 +14,10 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\fltMC.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: 4688 events with fltMC.exe
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/c27084dd0c432335fa4369e5002a61dfe0ab9c65/rules/windows/process_creation/win_sysmon_driver_unload.yml
+  - IOC: 4688 events with fltMC.exe
 Resources:
   - Link: https://www.darkoperator.com/blog/2018/10/5/operating-offensively-against-sysmon
 Acknowledgement:

--- a/yml/OSBinaries/Forfiles.yml
+++ b/yml/OSBinaries/Forfiles.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_indirect_cmd.yml
 Resources:
   - Link: https://twitter.com/vector_sec/status/896049052642533376
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Ftp.yml
+++ b/yml/OSBinaries/Ftp.yml
@@ -24,6 +24,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_ftp.yml
  - IOC: cmd /c as child process of ftp.exe
 Resources:
   - Link: https://twitter.com/0xAmit/status/1070063130636640256

--- a/yml/OSBinaries/GfxDownloadWrapper.yml
+++ b/yml/OSBinaries/GfxDownloadWrapper.yml
@@ -169,6 +169,7 @@ Full_Path:
   - Path: c:\windows\system32\driverstore\filerepository\ki132869.inf_amd64_052eb72d070df60f\
   - Path: c:\windows\system32\driverstore\filerepository\kit126731.inf_amd64_1905c9d5f38631d9\
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_file_download_via_gfxdownloadwrapper.yml
   - IOC: Usually GfxDownloadWrapper downloads a JSON file from https://gameplayapi.intel.com.
 Resources:
   - Link: https://www.sothis.tech/author/jgalvez/

--- a/yml/OSBinaries/Gpscript.yml
+++ b/yml/OSBinaries/Gpscript.yml
@@ -22,10 +22,11 @@ Full_Path:
   - Path: C:\Windows\System32\gpscript.exe
   - Path: C:\Windows\SysWOW64\gpscript.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Scripts added in local group policy
- - IOC: Execution of Gpscript.exe after logon
+  - Sigma: 
+  - IOC: Scripts added in local group policy
+  - IOC: Execution of Gpscript.exe after logon
 Resources:
   - Link: https://oddvar.moe/2018/04/27/gpscript-exe-another-lolbin-to-the-list/
 Acknowledgement:

--- a/yml/OSBinaries/Hh.yml
+++ b/yml/OSBinaries/Hh.yml
@@ -22,9 +22,10 @@ Full_Path:
   - Path: C:\Windows\System32\hh.exe
   - Path: C:\Windows\SysWOW64\hh.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: hh.exe should normally not be in use on a normal workstation
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_hh_chm.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_html_help_spawn.yml
 Resources:
   - Link: https://oddvar.moe/2017/08/13/bypassing-device-guard-umci-using-chm-cve-2017-8625/
 Acknowledgement:

--- a/yml/OSBinaries/IMEWDBLD.yml
+++ b/yml/OSBinaries/IMEWDBLD.yml
@@ -13,6 +13,8 @@ Commands:
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\IME\SHARED\IMEWDBLD.exe
+Detection:
+  - Sigma:
 Resources:
   - Link: https://twitter.com/notwhickey/status/1367493406835040265
 Acknowledgement:

--- a/yml/OSBinaries/Ie4uinit.yml
+++ b/yml/OSBinaries/Ie4uinit.yml
@@ -17,9 +17,11 @@ Full_Path:
   - Path: c:\windows\system32\ieuinit.inf
   - Path: c:\windows\sysWOW64\ieuinit.inf
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: ie4uinit.exe loading a inf file from outside %windir%
+  - Sigma: 
+  - IOC: ie4uinit.exe copied outside of %windir%
+  - IOC: ie4uinit.exe loading an inf file (ieuinit.inf) from outside %windir%
 Resources:
   - Link: https://bohops.com/2018/03/10/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence-part-2/
 Acknowledgement:

--- a/yml/OSBinaries/Ieexec.yml
+++ b/yml/OSBinaries/Ieexec.yml
@@ -24,7 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
+  - IOC: Network connections originating from ieexec.exe may be suspicious
 Resources:
   - Link: https://room362.com/post/2014/2014-01-16-application-whitelist-bypass-using-ieexec-dot-exe/
 Acknowledgement:

--- a/yml/OSBinaries/Ilasm.yml
+++ b/yml/OSBinaries/Ilasm.yml
@@ -5,14 +5,14 @@ Author: Hai vaknin (lux)
 Created: 2020-03-17
 Commands:
   - Command: ilasm.exe C:\public\test.txt /exe
-    Description: Binary file used by .NET to compile c# code to .exe
+    Description: Binary file used by .NET to compile C#/intermediate (IL) code to .exe
     Usecase: Compile attacker code on system. Bypass defensive counter measures.
     Category: Compile
     Privileges: User
     MitreID: T1127
     OperatingSystem: Windows 10,7
   - Command: ilasm.exe C:\public\test.txt /dll
-    Description: Binary file used by .NET to compile c# code to dll
+    Description: Binary file used by .NET to compile C#/intermediate (IL) code to dll
     Usecase: A description of the usecase
     Category: Compile
     Privileges: User
@@ -21,7 +21,10 @@ Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\ilasm.exe
   - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ilasm.exe
 Code_Sample:
-- Code:
+  - Code:
+Detection:
+  - Sigma:
+  - IOC: Ilasm may not be used often in production environments (such as on endpoints)
 Resources:
   - Link: https://github.com/LuxNoBulIshit/BeforeCompileBy-ilasm/blob/master/hello_world.txt
 Acknowledgement:

--- a/yml/OSBinaries/Infdefaultinstall.yml
+++ b/yml/OSBinaries/Infdefaultinstall.yml
@@ -17,10 +17,12 @@ Full_Path:
 Code_Sample:
 - Code: https://gist.github.com/KyleHanslovan/5e0f00d331984c1fb5be32c40f3b265a
 Detection:
- - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/85d47aeabc25bbd023284849f4466c1e00b855ce/rules/windows/process_creation/process_creation_infdefaultinstall.yml
+ - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://twitter.com/KyleHanslovan/status/911997635455852544
   - Link: https://blog.conscioushacker.io/index.php/2017/10/25/evading-microsofts-autoruns/
+  - Link: https://bohops.com/2018/03/10/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence-part-2/
 Acknowledgement:
   - Person: Kyle Hanslovan
     Handle: '@kylehanslovan'

--- a/yml/OSBinaries/Installutil.yml
+++ b/yml/OSBinaries/Installutil.yml
@@ -26,7 +26,7 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
 Resources:
   - Link: https://pentestlab.blog/2017/05/08/applocker-bypass-installutil/
   - Link: https://evi1cg.me/archives/AppLocker_Bypass_Techniques.html#menu_index_12

--- a/yml/OSBinaries/Jsc.yml
+++ b/yml/OSBinaries/Jsc.yml
@@ -24,9 +24,10 @@ Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\Jsc.exe
   - Path: C:\Windows\Microsoft.NET\Framework64\v2.0.50727\Jsc.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Jsc.exe should normally not run a system unless it is used for development.
+  - Sigma: 
+  - IOC: Jsc.exe should normally not run a system unless it is used for development.
 Resources:
   - Link: https://twitter.com/DissectMalware/status/998797808907046913
   - Link: https://www.phpied.com/make-your-javascript-a-windows-exe/

--- a/yml/OSBinaries/Makecab.yml
+++ b/yml/OSBinaries/Makecab.yml
@@ -29,10 +29,11 @@ Full_Path:
   - Path: C:\Windows\System32\makecab.exe
   - Path: C:\Windows\SysWOW64\makecab.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Makecab getting files from Internet
- - IOC: Makecab storing data into alternate data streams
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/688df3405afd778d63a2ea36a084344a2052848c/rules/windows/process_creation/process_creation_alternate_data_streams.yml
+  - IOC: Makecab retrieving files from Internet
+  - IOC: Makecab storing data into alternate data streams
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 Acknowledgement:

--- a/yml/OSBinaries/Mavinject.yml
+++ b/yml/OSBinaries/Mavinject.yml
@@ -22,9 +22,11 @@ Full_Path:
   - Path: C:\Windows\System32\mavinject.exe
   - Path: C:\Windows\SysWOW64\mavinject.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: mavinject.exe should not run unless APP-v is in use on the workstation
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_mavinject_proc_inj.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/c44b22b52fce406d45ddb6743a02b9ff8c62c7c6/rules/windows/process_creation/sysmon_creation_mavinject_dll.yml
+  - IOC: mavinject.exe should not run unless APP-v is in use on the workstation
 Resources:
   - Link: https://twitter.com/gN3mes1s/status/941315826107510784
   - Link: https://twitter.com/Hexcorn/status/776122138063409152

--- a/yml/OSBinaries/Microsoft.Workflow.Compiler.yml
+++ b/yml/OSBinaries/Microsoft.Workflow.Compiler.yml
@@ -28,11 +28,13 @@ Commands:
 Full_Path:
   - Path: C:\Windows\Microsoft.Net\Framework64\v4.0.30319\Microsoft.Workflow.Compiler.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Microsoft.Workflow.Compiler.exe would not normally be run on workstations.
- - IOC: The presence of csc.exe or vbc.exe as child processes of Microsoft.Workflow.Compiler.exe
- - IOC: Presence of "<CompilerInput" in a text file.
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/85d47aeabc25bbd023284849f4466c1e00b855ce/rules/windows/process_creation/win_workflow_compiler.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - IOC: Microsoft.Workflow.Compiler.exe would not normally be run on workstations.
+  - IOC: The presence of csc.exe or vbc.exe as child processes of Microsoft.Workflow.Compiler.exe
+  - IOC: Presence of "<CompilerInput" in a text file.
 Resources:
   - Link: https://twitter.com/mattifestation/status/1030445200475185154
   - Link: https://posts.specterops.io/arbitrary-unsigned-code-execution-vector-in-microsoft-workflow-compiler-exe-3d9294bc5efb

--- a/yml/OSBinaries/Mmc.yml
+++ b/yml/OSBinaries/Mmc.yml
@@ -17,7 +17,9 @@ Full_Path:
 Code_Sample:
 - Code:
 Detection:
- - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_mmc_spawn_shell.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/b731c2059445eef53e37232a5f3634c3473aae0c/rules/windows/file_event/sysmon_uac_bypass_dotnet_profiler.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/builtin/win_mmc20_lateral_movement.yml
 Resources:
   - Link: https://bohops.com/2018/08/18/abusing-the-com-registry-structure-part-2-loading-techniques-for-evasion-and-persistence/
 Acknowledgement:

--- a/yml/OSBinaries/MpCmdRun.yml
+++ b/yml/OSBinaries/MpCmdRun.yml
@@ -32,8 +32,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/159bf4bbc103cc2be3fef4b7c2e7c8b23b63fd10/rules/windows/process_creation/win_susp_mpcmdrun_download.yml
   - IOC: MpCmdRun storing data into alternate data streams.
-  - IOC: MpCmdRun getting a file from a remote machine or the internet that is not expected.
+  - IOC: MpCmdRun retrieving a file from a remote machine or the internet that is not expected.
   - IOC: Monitor process creation for non-SYSTEM and non-LOCAL SERVICE accounts launching mpcmdrun.exe.
   - IOC: Monitor for the creation of %USERPROFILE%\AppData\Local\Temp\MpCmdRun.log
   - IOC: User Agent is "MpCommunication"

--- a/yml/OSBinaries/Msbuild.yml
+++ b/yml/OSBinaries/Msbuild.yml
@@ -50,7 +50,10 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
- - IOC: Msbuild.exe should not normally be executed on workstations
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/5a3af872d86903c13e508348f54e3b519eb01dce/rules/windows/network_connection/silenttrinity_stager_msbuild_activity.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules 
+  - IOC: Msbuild.exe should not normally be executed on workstations
 Resources:
   - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1127/T1127.md
   - Link: https://github.com/Cn33liz/MSBuildShell

--- a/yml/OSBinaries/Msconfig.yml
+++ b/yml/OSBinaries/Msconfig.yml
@@ -14,10 +14,11 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\msconfig.exe
 Code_Sample:
-- Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/mscfgtlc.xml
+  - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/mscfgtlc.xml
 Detection:
- - IOC: mscfgtlc.xml changes in system32 folder
- - IOC: msconfig.exe executing
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/b731c2059445eef53e37232a5f3634c3473aae0c/rules/windows/process_creation/win_uac_bypass_msconfig_gui.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/b731c2059445eef53e37232a5f3634c3473aae0c/rules/windows/file_event/sysmon_uac_bypass_msconfig_gui.yml
+  - IOC: mscfgtlc.xml changes in system32 folder
 Resources:
   - Link: https://twitter.com/pabraeken/status/991314564896690177
 Acknowledgement:

--- a/yml/OSBinaries/Msdt.yml
+++ b/yml/OSBinaries/Msdt.yml
@@ -22,9 +22,9 @@ Full_Path:
   - Path: C:\Windows\System32\Msdt.exe
   - Path: C:\Windows\SysWOW64\Msdt.exe
 Code_Sample:
-- Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/PCW8E57.xml
+  - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/PCW8E57.xml
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
 Resources:
   - Link: https://web.archive.org/web/20160322142537/https://cybersyndicates.com/2015/10/a-no-bull-guide-to-malicious-windows-trouble-shooting-packs-and-application-whitelist-bypass/
   - Link: https://oddvar.moe/2017/12/21/applocker-case-study-how-insecure-is-it-really-part-2/

--- a/yml/OSBinaries/Mshta.yml
+++ b/yml/OSBinaries/Mshta.yml
@@ -49,6 +49,8 @@ Detection:
   - IOC: mshta.exe executing raw or obfuscated script within the command-line
   - IOC: General usage of HTA file
   - IOC: msthta.exe network connection to Internet/WWW resource
+  - IOC: DotNet CLR libraries loaded into mshta.exe
+  - IOC: DotNet CLR Usage Log - mshta.exe.log
 Resources:
   - Link: https://evi1cg.me/archives/AppLocker_Bypass_Techniques.html#menu_index_4
   - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/Windows/Payloads/mshta.sct

--- a/yml/OSBinaries/Mshta.yml
+++ b/yml/OSBinaries/Mshta.yml
@@ -36,10 +36,19 @@ Full_Path:
   - Path: C:\Windows\System32\mshta.exe
   - Path: C:\Windows\SysWOW64\mshta.exe
 Code_Sample:
-- Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/Mshta_calc.sct
+  - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/Mshta_calc.sct
 Detection:
- - IOC: mshta.exe executing raw or obfuscated script within the command-line
- - IOC: Usage of HTA file
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/05c58b4892942c34bfa01e9ada88ef2663858e1c/rules/windows/process_creation/win_susp_mshta_pattern.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_invoke_obfuscation_via_use_mhsta.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_lethalhta.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/f4ac416ef44862930730f8b7f16362b0e987bc71/rules/windows/process_creation/win_shell_spawn_mshta.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_mshta_javascript.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - IOC: mshta.exe executing raw or obfuscated script within the command-line
+  - IOC: General usage of HTA file
+  - IOC: msthta.exe network connection to Internet/WWW resource
 Resources:
   - Link: https://evi1cg.me/archives/AppLocker_Bypass_Techniques.html#menu_index_4
   - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/Windows/Payloads/mshta.sct

--- a/yml/OSBinaries/Msiexec.yml
+++ b/yml/OSBinaries/Msiexec.yml
@@ -38,7 +38,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC: msiexec.exe getting files from Internet
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_msiexec_web_install.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_msiexec_cwd.yml
+  - IOC: msiexec.exe retrieving files from Internet
 Resources:
   - Link: https://pentestlab.blog/2017/06/16/applocker-bypass-msiexec/
   - Link: https://twitter.com/PhilipTsukerman/status/992021361106268161

--- a/yml/OSBinaries/Netsh.yml
+++ b/yml/OSBinaries/Netsh.yml
@@ -17,6 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/0a410010a2655bc6f2aae73b9fb3b2c00ed589f7/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
   - IOC: Netsh initiating a network connection
 Resources:
   - Link: https://freddiebarrsmith.com/trix/trix.html

--- a/yml/OSBinaries/Odbcconf.yml
+++ b/yml/OSBinaries/Odbcconf.yml
@@ -22,9 +22,9 @@ Full_Path:
   - Path: C:\Windows\System32\odbcconf.exe
   - Path: C:\Windows\SysWOW64\odbcconf.exe
 Code_Sample:
-- Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/file.rsp
+  - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/file.rsp
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_odbcconf.yml
 Resources:
   - Link: https://gist.github.com/NickTyrer/6ef02ce3fd623483137b45f65017352b
   - Link: https://github.com/woanware/application-restriction-bypasses

--- a/yml/OSBinaries/OfflineScannerShell.yml
+++ b/yml/OSBinaries/OfflineScannerShell.yml
@@ -14,6 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Program Files\Windows Defender\Offline\OfflineScannerShell.exe
 Detection:
+  - Sigma:
   - IOC: OfflineScannerShell.exe should not be run on a normal workstation
 Acknowledgement:
   - Person: Elliot Killick

--- a/yml/OSBinaries/OneDriveStandaloneUpdater.yml
+++ b/yml/OSBinaries/OneDriveStandaloneUpdater.yml
@@ -14,6 +14,7 @@ Commands:
 Full_Path:
   - Path: '%localappdata%\Microsoft\OneDrive\OneDriveStandaloneUpdater.exe'
 Detection:
+  - Sigma:
   - IOC: HKCU\Software\Microsoft\OneDrive\UpdateOfficeConfig\UpdateRingSettingURLFromOC being set to a suspicious non-Microsoft controlled URL
   - IOC: Reports of downloading from suspicious URLs in %localappdata%\OneDrive\setup\logs\StandaloneUpdate_*.log files
 Resources:

--- a/yml/OSBinaries/Pcalua.yml
+++ b/yml/OSBinaries/Pcalua.yml
@@ -30,7 +30,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_indirect_cmd.yml
 Resources:
   - Link: https://twitter.com/KyleHanslovan/status/912659279806640128
 Acknowledgement:

--- a/yml/OSBinaries/Pcwrun.yml
+++ b/yml/OSBinaries/Pcwrun.yml
@@ -14,9 +14,9 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\pcwrun.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_indirect_cmd_compatibility_assistant.yml
 Resources:
   - Link: https://twitter.com/pabraeken/status/991335019833708544
 Acknowledgement:

--- a/yml/OSBinaries/Pktmon.yml
+++ b/yml/OSBinaries/Pktmon.yml
@@ -24,6 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma:
   - IOC: .etl files found on system
 Resources:
   - Link: https://binar-x79.com/windows-10-secret-sniffer/

--- a/yml/OSBinaries/Pnputil.yml
+++ b/yml/OSBinaries/Pnputil.yml
@@ -13,7 +13,10 @@ Commands:
     OperatingSystem: Windows 10,7
 Full_Path:
   - Path: C:\Windows\system32\pnputil.exe
-Code_Sample: https://github.com/LuxNoBulIshit/test.inf/blob/main/inf
+Code_Sample: 
+  - Code: https://github.com/LuxNoBulIshit/test.inf/blob/main/inf
+Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/a8a0d546f347febb0423aa920dbc10713cc1f92f/rules/windows/process_creation/process_creation_lolbins_suspicious_driver_installed_by_pnputil.yml
 Acknowledgement:
   - Person: Hai Vaknin(Lux)
     Handle: '@LuxNoBulIshit'

--- a/yml/OSBinaries/Presentationhost.yml
+++ b/yml/OSBinaries/Presentationhost.yml
@@ -15,9 +15,10 @@ Full_Path:
   - Path: C:\Windows\System32\Presentationhost.exe
   - Path: C:\Windows\SysWOW64\Presentationhost.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/commit/a38c0218765a89f5d18eadd49639c72a5d25d944
+  - IOC: Execution of .xbap files may not be common on production workstations
 Resources:
   - Link: https://github.com/api0cradle/ShmooCon-2015/blob/master/ShmooCon-2015-Simple-WLEvasion.pdf
   - Link: https://oddvar.moe/2017/12/21/applocker-case-study-how-insecure-is-it-really-part-2/

--- a/yml/OSBinaries/Print.yml
+++ b/yml/OSBinaries/Print.yml
@@ -29,10 +29,11 @@ Full_Path:
   - Path: C:\Windows\System32\print.exe
   - Path: C:\Windows\SysWOW64\print.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Print.exe getting files from internet
- - IOC: Print.exe creating executable files on disk
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_print.yml
+  - IOC: Print.exe retrieving files from internet
+  - IOC: Print.exe creating executable files on disk
 Resources:
   - Link: https://twitter.com/Oddvarmoe/status/985518877076541440
   - Link: https://www.youtube.com/watch?v=nPBcSP8M7KE&lc=z22fg1cbdkabdf3x404t1aokgwd2zxasf2j3rbozrswnrk0h00410

--- a/yml/OSBinaries/PrintBrm.yml
+++ b/yml/OSBinaries/PrintBrm.yml
@@ -21,6 +21,7 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\spool\tools\PrintBrm.exe
 Detection:
+  - Sigma:
   - IOC: PrintBrm.exe should not be run on a normal workstation
 Resources:
   - Link: https://twitter.com/elliotkillick/status/1404117015447670800

--- a/yml/OSBinaries/Psr.yml
+++ b/yml/OSBinaries/Psr.yml
@@ -17,6 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/c44b22b52fce406d45ddb6743a02b9ff8c62c7c6/rules/windows/process_creation/win_susp_psr_capture_screenshots.yml
   - IOC: psr.exe spawned
   - IOC: suspicious activity when running with "/gui 0" flag
 Resources:

--- a/yml/OSBinaries/Rasautou.yml
+++ b/yml/OSBinaries/Rasautou.yml
@@ -14,9 +14,10 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\rasautou.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: rasautou.exe command line containing -d and -p
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_rasautou_dll_execution.yml
+  - IOC: rasautou.exe command line containing -d and -p
 Resources:
   - Link: https://github.com/fireeye/DueDLLigence
   - Link: https://www.fireeye.com/blog/threat-research/2019/10/staying-hidden-on-the-endpoint-evading-detection-with-shellcode.html

--- a/yml/OSBinaries/Reg.yml
+++ b/yml/OSBinaries/Reg.yml
@@ -15,9 +15,11 @@ Full_Path:
   - Path: C:\Windows\System32\reg.exe
   - Path: C:\Windows\SysWOW64\reg.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: reg.exe writing to an ADS
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regedit_import_keys_ads.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regedit_import_keys.yml
+  - IOC: reg.exe writing to an ADS
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 Acknowledgement:

--- a/yml/OSBinaries/Regasm.yml
+++ b/yml/OSBinaries/Regasm.yml
@@ -24,9 +24,10 @@ Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\regasm.exe
   - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\regasm.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: regasm.exe executing dll file
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
+  - IOC: regasm.exe executing dll file
 Resources:
   - Link: https://pentestlab.blog/2017/05/19/applocker-bypass-regasm-and-regsvcs/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/

--- a/yml/OSBinaries/Regedit.yml
+++ b/yml/OSBinaries/Regedit.yml
@@ -22,10 +22,11 @@ Full_Path:
   - Path: C:\Windows\System32\regedit.exe
   - Path: C:\Windows\SysWOW64\regedit.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: regedit.exe reading and writing to alternate data stream
- - IOC: regedit.exe should normally not be executed by end-users
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regedit_import_keys_ads.yml
+  - IOC: regedit.exe reading and writing to alternate data stream
+  - IOC: regedit.exe should normally not be executed by end-users
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 Acknowledgement:

--- a/yml/OSBinaries/Regini.yml
+++ b/yml/OSBinaries/Regini.yml
@@ -15,9 +15,11 @@ Full_Path:
   - Path: C:\Windows\System32\regini.exe
   - Path: C:\Windows\SysWOW64\regini.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: regini.exe reading from ADS
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regini_ads.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regini.yml
+  - IOC: regini.exe reading from ADS
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 Acknowledgement:

--- a/yml/OSBinaries/Register-cimprovider.yml
+++ b/yml/OSBinaries/Register-cimprovider.yml
@@ -15,9 +15,10 @@ Full_Path:
   - Path: C:\Windows\System32\Register-cimprovider.exe
   - Path: C:\Windows\SysWOW64\Register-cimprovider.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+  - Sigma:
+  - IOC: Register-cimprovider.exe execution and cmdline DLL load may be supsicious
 Resources:
   - Link: https://twitter.com/PhilipTsukerman/status/992021361106268161
 Acknowledgement:

--- a/yml/OSBinaries/Regsvcs.yml
+++ b/yml/OSBinaries/Regsvcs.yml
@@ -22,9 +22,9 @@ Full_Path:
   - Path: C:\Windows\System32\regsvcs.exe
   - Path: C:\Windows\SysWOW64\regsvcs.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
 Resources:
   - Link: https://pentestlab.blog/2017/05/19/applocker-bypass-regasm-and-regsvcs/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/

--- a/yml/OSBinaries/Regsvr32.yml
+++ b/yml/OSBinaries/Regsvr32.yml
@@ -36,10 +36,15 @@ Full_Path:
   - Path: C:\Windows\System32\regsvr32.exe
   - Path: C:\Windows\SysWOW64\regsvr32.exe
 Code_Sample:
-- Code:
+ - Code:
 Detection:
- - IOC: regsvr32.exe getting files from Internet
- - IOC: regsvr32.exe executing scriptlet files
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/6fbce11094285e5ba13fe101b9cb70f5b1ece198/rules/windows/process_creation/win_susp_regsvr32_anomalies.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/6d56e400d209daa77a7900d950a7c587dc0cd2e5/rules/windows/network_connection/sysmon_regsvr32_network_activity.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/5951ad1d9a781a49d61df9af03c7b83ac67a0012/rules/windows/dns_query/dns_query_regsvr32_network_activity.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_regsvr32_flags_anomaly.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
+  - IOC: regsvr32.exe retrieving files from Internet
+  - IOC: regsvr32.exe executing scriptlet (sct) files
 Resources:
   - Link: https://pentestlab.blog/2017/05/11/applocker-bypass-regsvr32/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/

--- a/yml/OSBinaries/Regsvr32.yml
+++ b/yml/OSBinaries/Regsvr32.yml
@@ -45,6 +45,8 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
   - IOC: regsvr32.exe retrieving files from Internet
   - IOC: regsvr32.exe executing scriptlet (sct) files
+  - IOC: DotNet CLR libraries loaded into regsvr32.exe
+  - IOC: DotNet CLR Usage Log - regsvr32.exe.log
 Resources:
   - Link: https://pentestlab.blog/2017/05/11/applocker-bypass-regsvr32/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/

--- a/yml/OSBinaries/Replace.yml
+++ b/yml/OSBinaries/Replace.yml
@@ -22,9 +22,10 @@ Full_Path:
   - Path: C:\Windows\System32\replace.exe
   - Path: C:\Windows\SysWOW64\replace.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Replace.exe getting files from remote server
+  - Sigma:
+  - IOC: Replace.exe retrieving files from remote server
 Resources:
   - Link: https://twitter.com/elceef/status/986334113941655553
   - Link: https://twitter.com/elceef/status/986842299861782529

--- a/yml/OSBinaries/Rpcping.yml
+++ b/yml/OSBinaries/Rpcping.yml
@@ -22,9 +22,9 @@ Full_Path:
   - Path: C:\Windows\System32\rpcping.exe
   - Path: C:\Windows\SysWOW64\rpcping.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rpcping.yml
 Resources:
   - Link: https://github.com/vysec/RedTips
   - Link: https://twitter.com/vysecurity/status/974806438316072960

--- a/yml/OSBinaries/Rundll32.yml
+++ b/yml/OSBinaries/Rundll32.yml
@@ -64,9 +64,12 @@ Full_Path:
   - Path: C:\Windows\System32\rundll32.exe
   - Path: C:\Windows\SysWOW64\rundll32.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/network_connection/sysmon_rundll32_net_connections.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - IOC: Outbount Internet/network connections made from rundll32
+  - IOC: Suspicious use of cmdline flags such as -sta
 Resources:
   - Link: https://pentestlab.blog/2017/05/23/applocker-bypass-rundll32/
   - Link: https://evi1cg.me/archives/AppLocker_Bypass_Techniques.html#menu_index_7
@@ -75,6 +78,7 @@ Resources:
   - Link: https://bohops.com/2018/06/28/abusing-com-registry-structure-clsid-localserver32-inprocserver32/
   - Link: https://github.com/sailay1996/expl-bin/blob/master/obfus.md
   - Link: https://github.com/sailay1996/misc-bin/blob/master/rundll32.md
+  - Link: https://nasbench.medium.com/a-deep-dive-into-rundll32-exe-642344b41e90
 Acknowledgement:
   - Person: Casey Smith
     Handle: '@subtee'

--- a/yml/OSBinaries/Runonce.yml
+++ b/yml/OSBinaries/Runonce.yml
@@ -15,9 +15,11 @@ Full_Path:
   - Path: C:\Windows\System32\runonce.exe
   - Path: C:\Windows\SysWOW64\runonce.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components\YOURKEY
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/6d2acb166070541925636d1d1273e46020e38387/rules/windows/registry_event/sysmon_runonce_persistence.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_runonce_execution.yml
+  - IOC: Registy key add - HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components\YOURKEY
 Resources:
   - Link: https://twitter.com/pabraeken/status/990717080805789697
   - Link: https://cmatskas.com/configure-a-runonce-task-on-windows/

--- a/yml/OSBinaries/Runscripthelper.yml
+++ b/yml/OSBinaries/Runscripthelper.yml
@@ -15,10 +15,12 @@ Full_Path:
   - Path: C:\Windows\WinSxS\amd64_microsoft-windows-u..ed-telemetry-client_31bf3856ad364e35_10.0.16299.15_none_c2df1bba78111118\Runscripthelper.exe
   - Path: C:\Windows\WinSxS\amd64_microsoft-windows-u..ed-telemetry-client_31bf3856ad364e35_10.0.16299.192_none_ad4699b571e00c4a\Runscripthelper.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Event 4014 - Powershell logging
- - IOC: Event 400
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_runscripthelper.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules 
+  - IOC: Event 4014 - Powershell logging
+  - IOC: Event 400
 Resources:
   - Link: https://posts.specterops.io/bypassing-application-whitelisting-with-runscripthelper-exe-1906923658fc
 Acknowledgement:

--- a/yml/OSBinaries/Sc.yml
+++ b/yml/OSBinaries/Sc.yml
@@ -11,13 +11,24 @@ Commands:
     Privileges: User
     MitreID: T1564.004
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
+  - Command: sc config <existing> binPath="\"c:\\ADS\\file.txt:cmd.exe\" /c echo works > \"c:\ADS\works.txt\"" & sc start <existing>
+    Description: Modifies an existing service and executes the file stored in the ADS.
+    Usecase: Execute binary file hidden inside an alternate data stream
+    Category: ADS
+    Privileges: User
+    MitreID: T1564.004
+    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
 Full_Path:
   - Path: C:\Windows\System32\sc.exe
   - Path: C:\Windows\SysWOW64\sc.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Services that gets created
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_new_service_creation.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_using_sc_to_change_sevice_image_path_by_non_admin.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_susp_service_path_modification.yml
+  - IOC: Unexpected service creation
+  - IOC: Unexpected service modification
 Resources:
   - Link: https://oddvar.moe/2018/04/11/putting-data-in-alternate-data-streams-and-how-to-execute-it-part-2/
 Acknowledgement:

--- a/yml/OSBinaries/Schtasks.yml
+++ b/yml/OSBinaries/Schtasks.yml
@@ -17,7 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC: Services that gets created
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/59000b993d6280d9bf063eefdcdf30ea0e83aa5e/rules/windows/process_creation/win_susp_schtask_creation.yml
+  - IOC: Suspicious task creation events
 Resources:
   - Link: https://isc.sans.edu/forums/diary/Adding+Persistence+Via+Scheduled+Tasks/23633/
 Acknowledgement:

--- a/yml/OSBinaries/Scriptrunner.yml
+++ b/yml/OSBinaries/Scriptrunner.yml
@@ -22,9 +22,10 @@ Full_Path:
   - Path: C:\Windows\System32\scriptrunner.exe
   - Path: C:\Windows\SysWOW64\scriptrunner.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Scriptrunner.exe should not be in use unless App-v is deployed
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/765acac3742310764495ed5a2006bc0ced5b1a67/rules/windows/process_creation/win_susp_servu_process_pattern.yml
+  - IOC: Scriptrunner.exe should not be in use unless App-v is deployed
 Resources:
   - Link: https://twitter.com/KyleHanslovan/status/914800377580503040
   - Link: https://twitter.com/NickTyrer/status/914234924655312896

--- a/yml/OSBinaries/SettingSyncHost.yml
+++ b/yml/OSBinaries/SettingSyncHost.yml
@@ -22,6 +22,7 @@ Full_Path:
   - Path: C:\Windows\System32\SettingSyncHost.exe
   - Path: C:\Windows\SysWOW64\SettingSyncHost.exe
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_using_settingsynchost_as_lolbin.yml
   - IOC: SettingSyncHost.exe should not be run on a normal workstation
 Resources:
   - Link: https://www.hexacorn.com/blog/2020/02/02/settingsynchost-exe-as-a-lolbin/

--- a/yml/OSBinaries/Stordiag.yml
+++ b/yml/OSBinaries/Stordiag.yml
@@ -15,6 +15,7 @@ Full_Path:
   - Path: c:\windows\system32\stordiag.exe
   - Path: c:\windows\syswow64\stordiag.exe
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/8b86a79ef0ca2f32c006c327350b76b47b604690/rules/windows/process_creation/process_creation_stordiag_execution.yml
   - IOC: systeminfo.exe, fltmc.exe or schtasks.exe being executed outside of their normal path of c:\windows\system32\ or c:\windows\syswow64\
 Resources:
   - Link: https://twitter.com/eral4m/status/1451112385041911809

--- a/yml/OSBinaries/Syncappvpublishingserver.yml
+++ b/yml/OSBinaries/Syncappvpublishingserver.yml
@@ -15,9 +15,11 @@ Full_Path:
   - Path: C:\Windows\System32\SyncAppvPublishingServer.exe
   - Path: C:\Windows\SysWOW64\SyncAppvPublishingServer.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: SyncAppvPublishingServer.exe should never be in use unless App-V is deployed
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/fb750721b25ec4573acc32a0822d047a8ecdf269/rules/windows/deprecated/powershell_syncappvpublishingserver_exe.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/fb750721b25ec4573acc32a0822d047a8ecdf269/rules/windows/deprecated/process_creation_syncappvpublishingserver_exe.yml
+  - IOC: SyncAppvPublishingServer.exe should never be in use unless App-V is deployed
 Resources:
   - Link: https://twitter.com/monoxgas/status/895045566090010624
 Acknowledgement:

--- a/yml/OSBinaries/Ttdinject.yml
+++ b/yml/OSBinaries/Ttdinject.yml
@@ -24,6 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma:
   - IOC: Parent child relationship. Ttdinject.exe parent for executed command
   - IOC: Multiple queries made to the IFEO registry key of an untrusted executable (Ex. "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\payload.exe") from the ttdinject.exe process
 Resources:

--- a/yml/OSBinaries/Tttracer.yml
+++ b/yml/OSBinaries/Tttracer.yml
@@ -22,9 +22,11 @@ Full_Path:
   - Path: C:\Windows\System32\tttracer.exe
   - Path: C:\Windows\SysWOW64\tttracer.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Parent child relationship. Tttracer parent for executed command
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/5951ad1d9a781a49d61df9af03c7b83ac67a0012/rules/windows/image_load/process_creation_tttracer_mod_load.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/5951ad1d9a781a49d61df9af03c7b83ac67a0012/rules/windows/image_load/sysmon_tttracer_mod_load.yml
+  - IOC: Parent child relationship. Tttracer parent for executed command
 Resources:
   - Link: https://twitter.com/oulusoyum/status/1191329746069655553
   - Link: https://twitter.com/mattifestation/status/1196390321783025666

--- a/yml/OSBinaries/Vbc.yml
+++ b/yml/OSBinaries/Vbc.yml
@@ -22,7 +22,9 @@ Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\vbc.exe
   - Path: C:\Windows\Microsoft.NET\Framework64\v3.5\vbc.exe
 Code_Sample:
-- Code:
+   - Code:
+Detection:
+   - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_visual_basic_compiler.yml
 Acknowledgement:
   - Person: Lior Adar
     Handle:

--- a/yml/OSBinaries/Verclsid.yml
+++ b/yml/OSBinaries/Verclsid.yml
@@ -15,9 +15,9 @@ Full_Path:
   - Path: C:\Windows\System32\verclsid.exe
   - Path: C:\Windows\SysWOW64\verclsid.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_verclsid_runs_com.yml
 Resources:
   - Link: https://gist.github.com/NickTyrer/0598b60112eaafe6d07789f7964290d5
   - Link: https://bohops.com/2018/08/18/abusing-the-com-registry-structure-part-2-loading-techniques-for-evasion-and-persistence/

--- a/yml/OSBinaries/Wab.yml
+++ b/yml/OSBinaries/Wab.yml
@@ -17,6 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/a80c29a7c2e2e500a1a532db2a2a8bd69bd4a63d/rules/windows/registry_event/sysmon_wab_dllpath_reg_change.yml
   - IOC: WAB.exe should normally never be used
 Resources:
   - Link: https://twitter.com/Hexacorn/status/991447379864932352

--- a/yml/OSBinaries/Wmic.yml
+++ b/yml/OSBinaries/Wmic.yml
@@ -66,6 +66,11 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/8beb70e970b814d0ab60625206ea0d8a21a9bff8/rules/windows/image_load/sysmon_wmic_remote_xsl_scripting_dlls.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_xsl_script_processing.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_bypass_squiblytwo.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/c90e31275d2f98b21e55df8a46d0678cfca458d6/rules/windows/process_creation/win_susp_wmic_eventconsumer_create.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules 
   - IOC: Wmic getting scripts from remote system
 Resources:
   - Link: https://stackoverflow.com/questions/24658745/wmic-how-to-use-process-call-create-with-a-specific-working-directory

--- a/yml/OSBinaries/WorkFolders.yml
+++ b/yml/OSBinaries/WorkFolders.yml
@@ -14,6 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\WorkFolders.exe
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/b4d5b44ea86cda24f38a87d3b0c5f9d4455bf841/rules/windows/process_creation/win_susp_workfolders.yml
   - IOC: WorkFolders.exe should not be run on a normal workstation
 Resources:
   - Link: https://www.ctus.io/2021/04/12/exploading/

--- a/yml/OSBinaries/Wscript.yml
+++ b/yml/OSBinaries/Wscript.yml
@@ -29,6 +29,8 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules 
   - IOC: Wscript.exe executing code from alternate data streams
+  - IOC: DotNet CLR libraries loaded into wscript.exe
+  - IOC: DotNet CLR Usage Log - wscript.exe.log
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 Acknowledgement:

--- a/yml/OSBinaries/Wscript.yml
+++ b/yml/OSBinaries/Wscript.yml
@@ -22,9 +22,13 @@ Full_Path:
   - Path: C:\Windows\System32\wscript.exe
   - Path: C:\Windows\SysWOW64\wscript.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: Wscript.exe executing code from alternate data streams
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_script_execution.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules 
+  - IOC: Wscript.exe executing code from alternate data streams
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 Acknowledgement:

--- a/yml/OSBinaries/Wsreset.yml
+++ b/yml/OSBinaries/Wsreset.yml
@@ -16,9 +16,13 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
- - IOC: wsreset.exe launching child process other than mmc.exe
- - IOC: Creation or modification of the registry value HKCU\Software\Classes\AppX82a6gwre4fdg3bt635tn5ctqjf8msdd2\Shell\open\command
- - IOC: Microsoft Defender Antivirus as Behavior:Win32/UACBypassExp.T!gen
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_wsreset_uac_bypass.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/af599e487728ec95eab96d8a980718aa6a0699e4/rules/windows/process_creation/win_uac_bypass_wsreset.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_uac_wsreset.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/registry_event/sysmon_bypass_via_wsreset.yml
+  - IOC: wsreset.exe launching child process other than mmc.exe
+  - IOC: Creation or modification of the registry value HKCU\Software\Classes\AppX82a6gwre4fdg3bt635tn5ctqjf8msdd2\Shell\open\command
+  - IOC: Microsoft Defender Antivirus as Behavior:Win32/UACBypassExp.T!gen
 Resources:
   - Link: https://www.activecyber.us/activelabs/windows-uac-bypass
   - Link: https://twitter.com/ihack4falafel/status/1106644790114947073

--- a/yml/OSBinaries/Wuauclt.yml
+++ b/yml/OSBinaries/Wuauclt.yml
@@ -14,9 +14,13 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\wuauclt.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC: wuauclt run with a parameter of a DLL path
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/network_connection/sysmon_wuauclt_network_connection.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/f16aca7a353bb01d9862ea1f2a10fa0d866e83c3/rules/windows/process_creation/sysmon_proxy_execution_wuauclt.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/30bee7204cc1b98a47635ed8e52f44fdf776c602/rules/windows/process_creation/win_susp_wuauclt.yml 
+  - IOC: wuauclt run with a parameter of a DLL path
+  - IOC: Suspicious wuauclt Internet/network connections
 Resources:
   - Link: https://dtm.uk/wuauclt/
 Acknowledgement:

--- a/yml/OSBinaries/Xwizard.yml
+++ b/yml/OSBinaries/Xwizard.yml
@@ -29,9 +29,10 @@ Full_Path:
   - Path: C:\Windows\System32\xwizard.exe
   - Path: C:\Windows\SysWOW64\xwizard.exe
 Code_Sample:
-- Code:
+  - Code:
 Detection:
- - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_class_exec_xwizard.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/8909eefb90c799fb642f6d9d0d6ee6d855a6a654/rules/windows/process_creation/win_dll_sideload_xwizard.yml
 Resources:
   - Link: http://www.hexacorn.com/blog/2017/07/31/the-wizard-of-x-oppa-plugx-style/
   - Link: https://www.youtube.com/watch?v=LwDHX7DVHWU

--- a/yml/OSLibraries/Advpack.yml
+++ b/yml/OSLibraries/Advpack.yml
@@ -46,7 +46,7 @@ Code_Sample:
   - Code: https://github.com/LOLBAS-Project/LOLBAS-Project.github.io/blob/master/_lolbas/Libraries/Payload/Advpack.inf
   - Code: https://github.com/LOLBAS-Project/LOLBAS-Project.github.io/blob/master/_lolbas/Libraries/Payload/Advpack_calc.sct
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://bohops.com/2018/02/26/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence/
   - Link: https://twitter.com/ItsReallyNick/status/967859147977850880

--- a/yml/OSLibraries/Dfshim.yml
+++ b/yml/OSLibraries/Dfshim.yml
@@ -1,0 +1,29 @@
+---
+Name: Dfshim.dll
+Description: ClickOnce engine in Windows used by .NET
+Author: 'Oddvar Moe'
+Created: 2018-05-25
+Commands:
+  - Command: rundll32.exe dfshim.dll,ShOpenVerbApplication http://www.domain.com/application/?param1=foo
+    Description: Executes click-once-application from Url (trampoline for Dfsvc.exe, DotNet ClickOnce host)
+    Usecase: Use binary to bypass Application whitelisting
+    Category: AWL bypass
+    Privileges: User
+    MitreID: T1127
+    OperatingSystem: Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
+Full_Path:
+  - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\Dfsvc.exe
+  - Path: C:\Windows\Microsoft.NET\Framework64\v2.0.50727\Dfsvc.exe
+  - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\Dfsvc.exe
+  - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Dfsvc.exe
+Code_Sample:
+- Code:
+Detection:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+Resources:
+  - Link: https://github.com/api0cradle/ShmooCon-2015/blob/master/ShmooCon-2015-Simple-WLEvasion.pdf
+  - Link: https://stackoverflow.com/questions/13312273/clickonce-runtime-dfsvc-exe
+Acknowledgement:
+  - Person: Casey Smith
+    Handle: '@subtee'
+---

--- a/yml/OSLibraries/Ieadvpack.yml
+++ b/yml/OSLibraries/Ieadvpack.yml
@@ -44,7 +44,7 @@ Code_Sample:
   - Code: https://github.com/LOLBAS-Project/LOLBAS-Project.github.io/blob/master/_lolbas/Libraries/Payload/Ieadvpack.inf
   - Code: https://github.com/LOLBAS-Project/LOLBAS-Project.github.io/blob/master/_lolbas/Libraries/Payload/Ieadvpack_calc.sct
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://bohops.com/2018/03/10/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence-part-2/
   - Link: https://twitter.com/pabraeken/status/991695411902599168

--- a/yml/OSLibraries/Ieframe.yml
+++ b/yml/OSLibraries/Ieframe.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.githubusercontent.com/bohops/89d7b11fa32062cfe31be9fdb18f050e/raw/1206a613a6621da21e7fd164b80a7ff01c5b64ab/calc.url
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: http://www.hexacorn.com/blog/2018/03/15/running-programs-via-proxy-jumping-on-a-edr-bypass-trampoline-part-5/
   - Link: https://bohops.com/2018/03/17/abusing-exported-functions-and-exposed-dcom-interfaces-for-pass-thru-command-execution-and-lateral-movement/

--- a/yml/OSLibraries/Mshtml.yml
+++ b/yml/OSLibraries/Mshtml.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://twitter.com/pabraeken/status/998567549670477824
   - Link: https://windows10dll.nirsoft.net/mshtml_dll.html

--- a/yml/OSLibraries/Pcwutl.yml
+++ b/yml/OSLibraries/Pcwutl.yml
@@ -17,7 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Blog: https://redcanary.com/threat-detection-report/techniques/rundll32/
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://twitter.com/harr0ey/status/989617817849876488
   - Link: https://windows10dll.nirsoft.net/pcwutl_dll.html

--- a/yml/OSLibraries/Setupapi.yml
+++ b/yml/OSLibraries/Setupapi.yml
@@ -27,7 +27,8 @@ Code_Sample:
   - Code: https://gist.githubusercontent.com/enigma0x3/469d82d1b7ecaf84f4fb9e6c392d25ba/raw/6cb52b88bcc929f5555cd302d9ed848b7e407052/Backdoor-Minimalist.sct
   - Code: https://gist.githubusercontent.com/bohops/0cc6586f205f3691e04a1ebf1806aabd/raw/baf7b29891bb91e76198e30889fbf7d6642e8974/calc_exe.inf
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_setupapi_installhinfsection.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://github.com/huntresslabs/evading-autoruns
   - Link: https://twitter.com/pabraeken/status/994742106852941825

--- a/yml/OSLibraries/Shdocvw.yml
+++ b/yml/OSLibraries/Shdocvw.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.githubusercontent.com/bohops/89d7b11fa32062cfe31be9fdb18f050e/raw/1206a613a6621da21e7fd164b80a7ff01c5b64ab/calc.url
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
     - Link: http://www.hexacorn.com/blog/2018/03/15/running-programs-via-proxy-jumping-on-a-edr-bypass-trampoline-part-5/
     - Link: https://bohops.com/2018/03/17/abusing-exported-functions-and-exposed-dcom-interfaces-for-pass-thru-command-execution-and-lateral-movement/

--- a/yml/OSLibraries/Shell32.yml
+++ b/yml/OSLibraries/Shell32.yml
@@ -29,7 +29,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://twitter.com/Hexacorn/status/885258886428725250
   - Link: https://twitter.com/pabraeken/status/991768766898941953

--- a/yml/OSLibraries/Syssetup.yml
+++ b/yml/OSLibraries/Syssetup.yml
@@ -26,7 +26,7 @@ Code_Sample:
   - Code: https://gist.github.com/enigma0x3/469d82d1b7ecaf84f4fb9e6c392d25ba#file-backdoor-minimalist-sct
   - Code: https://gist.github.com/homjxi0e/87b29da0d4f504cb675bb1140a931415
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://twitter.com/pabraeken/status/994392481927258113
   - Link: https://twitter.com/harr0ey/status/975350238184697857

--- a/yml/OSLibraries/Url.yml
+++ b/yml/OSLibraries/Url.yml
@@ -52,7 +52,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://bohops.com/2018/03/17/abusing-exported-functions-and-exposed-dcom-interfaces-for-pass-thru-command-execution-and-lateral-movement/
   - Link: https://twitter.com/DissectMalware/status/995348436353470465

--- a/yml/OSLibraries/Zipfldr.yml
+++ b/yml/OSLibraries/Zipfldr.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
 Resources:
   - Link: https://twitter.com/moriarty_meng/status/977848311603380224
   - Link: https://twitter.com/bohops/status/997896811904929792

--- a/yml/OSLibraries/comsvcs.yml
+++ b/yml/OSLibraries/comsvcs.yml
@@ -16,7 +16,9 @@ Full_Path:
 Code_Sample:
   - Code: https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/
 Detection:
-  - IOC: MiniDump being used in library
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/1ff5e226ad8bed34916c16ccc77ba281ca3203ae/rules/windows/process_creation/win_process_dump_rundll32_comsvcs.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/b81839e3ce507df925d6e583e569e1ac3a3894ab/rules/windows/process_access/sysmon_lsass_dump_comsvcs_dll.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_comsvcs_procdump.yml
 Resources:
   - Link: https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/
 Acknowledgement:

--- a/yml/OSScripts/CL_LoadAssembly.yml
+++ b/yml/OSScripts/CL_LoadAssembly.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma:
 Resources:
   - Link: https://bohops.com/2018/01/07/executing-commands-and-bypassing-applocker-with-powershell-diagnostic-scripts/
 Acknowledgement:

--- a/yml/OSScripts/CL_mutexverifiers.yml
+++ b/yml/OSScripts/CL_mutexverifiers.yml
@@ -20,7 +20,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma:
 Resources:
   - Link: https://twitter.com/pabraeken/status/995111125447577600
 Acknowledgement:

--- a/yml/OSScripts/Cl_invocation.yml
+++ b/yml/OSScripts/Cl_invocation.yml
@@ -18,7 +18,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/2d36d62e88c45a59e22d17849b41ba346a1cb66a/rules/windows/process_creation/win_cl_invocation_lolscript.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/e5b3a1cc14aaad6f2acc569fab9849567f98df3e/rules/windows/powershell/powershell_script/powershell_cl_invocation_lolscript_count.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/e5b3a1cc14aaad6f2acc569fab9849567f98df3e/rules/windows/powershell/powershell_script/powershell_cl_invocation_lolscript.yml
 Resources:
   - Link:
 Acknowledgement:

--- a/yml/OSScripts/Manage-bde.yml
+++ b/yml/OSScripts/Manage-bde.yml
@@ -23,7 +23,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC: Manage-bde.wsf should normally not be invoked by a user
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/3107ede1c4d253c89a26f3a0be79122a3a562f29/rules/windows/process_creation/win_manage_bde_lolbas.yml
+  - IOC: Manage-bde.wsf should not be invoked by a standard user under normal situations
 Resources:
   - Link: https://gist.github.com/bohops/735edb7494fe1bd1010d67823842b712
   - Link: https://twitter.com/bohops/status/980659399495741441

--- a/yml/OSScripts/Pubprn.yml
+++ b/yml/OSScripts/Pubprn.yml
@@ -17,7 +17,8 @@ Full_Path:
 Code_Sample:
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSScripts/Payload/Pubprn_calc.sct
 Detection:
-  - IOC:
+  - Sigma:
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/
   - Link: https://www.slideshare.net/enigma0x3/windows-operating-system-archaeology

--- a/yml/OSScripts/Syncappvpublishingserver.yml
+++ b/yml/OSScripts/Syncappvpublishingserver.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/973e0666acffb8fd7ea8356449eb916381ab0cc6/rules/windows/process_creation/process_creation_syncappvpublishingserver_vbs_execute_powershell.yml
 Resources:
   - Link: https://twitter.com/monoxgas/status/895045566090010624
   - Link: https://twitter.com/subTee/status/855738126882316288

--- a/yml/OSScripts/UtilityFunctions.yml
+++ b/yml/OSScripts/UtilityFunctions.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma:
 Resources:
   - Link: https://twitter.com/nickvangilder/status/1441003666274668546
 Acknowledgement:

--- a/yml/OSScripts/Winrm.yml
+++ b/yml/OSScripts/Winrm.yml
@@ -32,7 +32,10 @@ Code_Sample:
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSScripts/Payload/Slmgr.reg
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSScripts/Payload/Slmgr_calc.sct
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/10b70edff055cfb12b16d934c77f9ccf4b97a529/rules/windows/process_creation/win_susp_winrm_awl_bypass.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/process_creation/win_susp_winrm_execution.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/3107ede1c4d253c89a26f3a0be79122a3a562f29/rules/windows/file_event/file_event_winrm_awl_bypass.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://www.slideshare.net/enigma0x3/windows-operating-system-archaeology
   - Link: https://www.youtube.com/watch?v=3gz1QmiMhss

--- a/yml/OSScripts/pester.yml
+++ b/yml/OSScripts/pester.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_pester.yml
 Resources:
   - Link: https://twitter.com/Oddvarmoe/status/993383596244258816
 Acknowledgement:

--- a/yml/OtherMSBinaries/Adplus.yml
+++ b/yml/OtherMSBinaries/Adplus.yml
@@ -17,7 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma:
+  - IOC: As a Windows SDK binary, execution on a system may be suspicious
 Resources:
   - Link: https://blog.thecybersecuritytutor.com/adplus-debugging-tool-lsass-dump/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Agentexecutor.yml
+++ b/yml/OtherMSBinaries/Agentexecutor.yml
@@ -23,7 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma:
 Resources:
   - Link:
 Acknowledgement:

--- a/yml/OtherMSBinaries/Appvlp.yml
+++ b/yml/OtherMSBinaries/Appvlp.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/8b170ff5628376c87632635a5fde4e48bba70275/rules/windows/builtin/win_asr_bypass_via_appvlp_re.yml
 Resources:
   - Link: https://github.com/MoooKitty/Code-Execution
   - Link: https://twitter.com/moo_hax/status/892388990686347264

--- a/yml/OtherMSBinaries/Bginfo.yml
+++ b/yml/OtherMSBinaries/Bginfo.yml
@@ -51,7 +51,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_bginfo.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://oddvar.moe/2017/05/18/bypassing-application-whitelisting-with-bginfo/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Cdb.yml
+++ b/yml/OtherMSBinaries/Cdb.yml
@@ -26,7 +26,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_cdb.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: http://www.exploit-monday.com/2016/08/windbg-cdb-shellcode-runner.html
   - Link: https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/cdb-command-line-options

--- a/yml/OtherMSBinaries/Coregen.yml
+++ b/yml/OtherMSBinaries/Coregen.yml
@@ -31,6 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma:
   - IOC: coregen.exe loading .dll file not in "C:\Program Files (x86)\Microsoft Silverlight\5.1.50918.0\"
   - IOC: coregen.exe loading .dll file not named coreclr.dll
   - IOC: coregen.exe command line containing -L or -l

--- a/yml/OtherMSBinaries/Csi.yml
+++ b/yml/OtherMSBinaries/Csi.yml
@@ -17,7 +17,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/process_creation/win_susp_csi.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_use_of_csharp_console.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://twitter.com/subTee/status/781208810723549188
   - Link: https://enigma0x3.net/2016/11/17/bypassing-application-whitelisting-by-using-dnx-exe/

--- a/yml/OtherMSBinaries/DefaultPack.yml
+++ b/yml/OtherMSBinaries/DefaultPack.yml
@@ -16,6 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma:
   - IOC: DefaultPack.EXE spawned an unknown process
 Resources:
   - Link: https://twitter.com/checkymander/status/1311509470275604480.

--- a/yml/OtherMSBinaries/Devtoolslauncher.yml
+++ b/yml/OtherMSBinaries/Devtoolslauncher.yml
@@ -23,6 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_devtoolslauncher.yml
   - IOC: DeveloperToolsSvc.exe spawned an unknown process
 Resources:
   - Link: https://twitter.com/_felamos/status/1179811992841797632

--- a/yml/OtherMSBinaries/Dnx.yml
+++ b/yml/OtherMSBinaries/Dnx.yml
@@ -16,7 +16,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_dnx.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://enigma0x3.net/2016/11/17/bypassing-application-whitelisting-by-using-dnx-exe/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Dotnet.yml
+++ b/yml/OtherMSBinaries/Dotnet.yml
@@ -26,6 +26,8 @@ Commands:
 Full_Path:
   - Path: 'C:\Program Files\dotnet\dotnet.exe'
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/0bf262539301693a18646056ea789b9b56b9c7f6/rules/windows/process_creation/process_creation_dotnet.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: dotnet.exe spawned an unknown process
 Resources:
   - Link: https://twitter.com/_felamos/status/1204705548668555264

--- a/yml/OtherMSBinaries/Dxcap.yml
+++ b/yml/OtherMSBinaries/Dxcap.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_dxcap.yml
 Resources:
   - Link: https://twitter.com/harr0ey/status/992008180904419328
 Acknowledgement:

--- a/yml/OtherMSBinaries/Excel.yml
+++ b/yml/OtherMSBinaries/Excel.yml
@@ -30,7 +30,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_msoffice.yml
+  - IOC: Suspicious Office application Internet/network traffic
 Resources:
   - Link: https://twitter.com/reegun21/status/1150032506504151040
   - Link: https://medium.com/@reegun/unsanitized-file-validation-leads-to-malicious-payload-download-via-office-binaries-202d02db7191

--- a/yml/OtherMSBinaries/Fsi.yml
+++ b/yml/OtherMSBinaries/Fsi.yml
@@ -24,7 +24,9 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.github.com/NickTyrer/51eb8c774a909634fa69b4d06fc79ae1
 Detection:
-  - IOC: Sysmon Event ID 1 - Process Creation
+  - Sigma:
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - IOC: Fsi.exe execution may be suspicious on non-developer machines
 Resources:
   - Link: https://twitter.com/NickTyrer/status/904273264385589248
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/

--- a/yml/OtherMSBinaries/FsiAnyCpu.yml
+++ b/yml/OtherMSBinaries/FsiAnyCpu.yml
@@ -23,7 +23,9 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.github.com/NickTyrer/51eb8c774a909634fa69b4d06fc79ae1
 Detection:
-  - IOC: Sysmon Event ID 1 - Process Creation
+  - Sigma:
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - IOC: FsiAnyCpu.exe execution may be suspicious on non-developer machines
 Resources:
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Mftrace.yml
+++ b/yml/OtherMSBinaries/Mftrace.yml
@@ -26,7 +26,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma:
 Resources:
   - Link: https://twitter.com/0rbz_/status/988911181422186496
 Acknowledgement:

--- a/yml/OtherMSBinaries/Msdeploy.yml
+++ b/yml/OtherMSBinaries/Msdeploy.yml
@@ -23,7 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/f16aca7a353bb01d9862ea1f2a10fa0d866e83c3/rules/windows/process_creation/process_creation_msdeploy.yml
 Resources:
   - Link: https://twitter.com/pabraeken/status/995837734379032576
   - Link: https://twitter.com/pabraeken/status/999090532839313408

--- a/yml/OtherMSBinaries/Msxsl.yml
+++ b/yml/OtherMSBinaries/Msxsl.yml
@@ -37,7 +37,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - IOC: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_xsl_script_processing.yml
 Resources:
   - Link: https://twitter.com/subTee/status/877616321747271680
   - Link: https://github.com/3gstudent/Use-msxsl-to-bypass-AppLocker

--- a/yml/OtherMSBinaries/Msxsl.yml
+++ b/yml/OtherMSBinaries/Msxsl.yml
@@ -37,7 +37,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_xsl_script_processing.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_xsl_script_processing.yml
 Resources:
   - Link: https://twitter.com/subTee/status/877616321747271680
   - Link: https://github.com/3gstudent/Use-msxsl-to-bypass-AppLocker

--- a/yml/OtherMSBinaries/Ntdsutil.yml
+++ b/yml/OtherMSBinaries/Ntdsutil.yml
@@ -16,6 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_ntdsutil.yml
   - IOC: ntdsutil.exe with command line including "ifm"
 Resources:
   - Link: https://adsecurity.org/?p=2398#CreateIFM

--- a/yml/OtherMSBinaries/Powerpnt.yml
+++ b/yml/OtherMSBinaries/Powerpnt.yml
@@ -27,6 +27,9 @@ Full_Path:
   - Path: C:\Program Files (x86)\Microsoft Office\Office12\Powerpnt.exe
   - Path: C:\Program Files\Microsoft Office\Office12\Powerpnt.exe
   - Path: C:\Program Files\Microsoft Office\Office12\Powerpnt.exe
+Detection:
+  - Sigma:
+  - IOC: Suspicious Office application Internet/network traffic
 Resources:
   - Link: https://twitter.com/reegun21/status/1150032506504151040
   - Link: https://medium.com/@reegun/unsanitized-file-validation-leads-to-malicious-payload-download-via-office-binaries-202d02db7191

--- a/yml/OtherMSBinaries/Procdump.yml
+++ b/yml/OtherMSBinaries/Procdump.yml
@@ -19,6 +19,8 @@ Commands:
     MitreID: T1202
     OperatingSystem: Windows 8.1 and higher, Windows Server 2012 and higher.
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/f36b1cbd2a3f1a7423f43a67a182549778700615/rules/windows/process_creation/win_susp_procdump.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/f36b1cbd2a3f1a7423f43a67a182549778700615/rules/windows/process_creation/win_procdump.yml
   - IOC: Process creation with given '-md' parameter
   - IOC: Anomalous child processes of procdump
   - IOC: Unsigned DLL load via procdump.exe or procdump64.exe

--- a/yml/OtherMSBinaries/Rcsi.yml
+++ b/yml/OtherMSBinaries/Rcsi.yml
@@ -23,7 +23,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/process_creation/win_susp_csi.yml
+  - BlockRule: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/process_creation/win_susp_csi.yml
 Resources:
   - Link: https://enigma0x3.net/2016/11/21/bypassing-application-whitelisting-by-using-rcsi-exe/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Remote.yml
+++ b/yml/OtherMSBinaries/Remote.yml
@@ -31,7 +31,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC: remote.exe spawned
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/network_connection/sysmon_susp_rdp.yml
+  - IOC: remote.exe process spawns
 Resources:
   - Link: https://blog.thecybersecuritytutor.com/Exeuction-AWL-Bypass-Remote-exe-LOLBin/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Remote.yml
+++ b/yml/OtherMSBinaries/Remote.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/network_connection/sysmon_susp_rdp.yml
+  - Sigma:
   - IOC: remote.exe process spawns
 Resources:
   - Link: https://blog.thecybersecuritytutor.com/Exeuction-AWL-Bypass-Remote-exe-LOLBin/

--- a/yml/OtherMSBinaries/Sqldumper.yml
+++ b/yml/OtherMSBinaries/Sqldumper.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_sqldumper_activity.yml
 Resources:
   - Link: https://twitter.com/countuponsec/status/910969424215232518
   - Link: https://twitter.com/countuponsec/status/910977826853068800

--- a/yml/OtherMSBinaries/Sqlps.yml
+++ b/yml/OtherMSBinaries/Sqlps.yml
@@ -19,7 +19,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_use_of_sqlps_bin.yml
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/80d2aee9449050652ca02fe8892e7bc23de3b70c/rules/windows/image_load/sysmon_in_memory_powershell.yml
 Resources:
   - Link: https://twitter.com/bryon_/status/975835709587075072
   - Link: https://docs.microsoft.com/en-us/sql/powershell/sql-server-powershell?view=sql-server-2017

--- a/yml/OtherMSBinaries/Sqltoolsps.yml
+++ b/yml/OtherMSBinaries/Sqltoolsps.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_use_of_sqltoolsps_bin.yml
 Resources:
   - Link: https://twitter.com/pabraeken/status/993298228840992768
   - Link: https://docs.microsoft.com/en-us/sql/powershell/sql-server-powershell?view=sql-server-2017

--- a/yml/OtherMSBinaries/Squirrel.yml
+++ b/yml/OtherMSBinaries/Squirrel.yml
@@ -44,7 +44,7 @@ Full_Path:
 Code_Sample:
   - Code: https://github.com/jreegun/POC-s/tree/master/nuget-squirrel
 Detection:
-  - IOC: Update.exe spawned an unknown process
+  - Sigma:
 Resources:
   - Link: https://www.youtube.com/watch?v=rOP3hnkj7ls
   - Link: https://twitter.com/reegun21/status/1144182772623269889

--- a/yml/OtherMSBinaries/Te.yml
+++ b/yml/OtherMSBinaries/Te.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_use_of_te_bin.yml
 Resources:
   - Link: https://twitter.com/gn3mes1s/status/927680266390384640?lang=bg
 Acknowledgement:

--- a/yml/OtherMSBinaries/Tracker.yml
+++ b/yml/OtherMSBinaries/Tracker.yml
@@ -23,7 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_tracker_execution.yml
 Resources:
   - Link: https://twitter.com/subTee/status/793151392185589760
   - Link: https://attack.mitre.org/wiki/Execution

--- a/yml/OtherMSBinaries/Update.yml
+++ b/yml/OtherMSBinaries/Update.yml
@@ -100,6 +100,7 @@ Full_Path:
 Code_Sample:
   - Code: https://github.com/jreegun/POC-s/tree/master/nuget-squirrel
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_squirrel_lolbin.yml
   - IOC: Update.exe spawned an unknown process
 Resources:
   - Link: https://www.youtube.com/watch?v=rOP3hnkj7ls

--- a/yml/OtherMSBinaries/VSIISExeLauncher.yml
+++ b/yml/OtherMSBinaries/VSIISExeLauncher.yml
@@ -16,6 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma:
   - IOC: VSIISExeLauncher.exe spawned an unknown process
 Resources:
   - Link: https://github.com/timwhitez

--- a/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
+++ b/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
@@ -18,7 +18,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  
+  - Sigma:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: As a Windows SDK binary, execution on a system may be suspicious
 Resources:

--- a/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
+++ b/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
@@ -18,7 +18,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC: Sysmon Event ID 1 - Process Creation
+  
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - IOC: As a Windows SDK binary, execution on a system may be suspicious
 Resources:
   - Link: https://bohops.com/2020/10/15/exploring-the-wdac-microsoft-recommended-block-rules-visualuiaverifynative/
   - Link: https://github.com/MicrosoftDocs/windows-itpro-docs/commit/937db704b9148e9cee7c7010cad4d00ce9c4fdad

--- a/yml/OtherMSBinaries/Vsjitdebugger.yml
+++ b/yml/OtherMSBinaries/Vsjitdebugger.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/8beb70e970b814d0ab60625206ea0d8a21a9bff8/rules/windows/process_creation/win_susp_use_of_vsjitdebugger_bin.yml
 Resources:
   - Link: https://twitter.com/pabraeken/status/990758590020452353
 Acknowledgement:

--- a/yml/OtherMSBinaries/Wfc.yml
+++ b/yml/OtherMSBinaries/Wfc.yml
@@ -16,7 +16,9 @@ Full_Path:
 Code_Sample:
   - Code: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/
 Detection:
-  - IOC: Sysmon Event ID 1 - Process Creation
+  - Sigma:
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - IOC: As a Windows SDK binary, execution on a system may be suspicious
 Resources:
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Winword.yml
+++ b/yml/OtherMSBinaries/Winword.yml
@@ -31,7 +31,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - IOC:
+  - Sigma:
+  - IOC: Suspicious Office application Internet/network traffic
 Resources:
   - Link: https://twitter.com/reegun21/status/1150032506504151040
   - Link: https://medium.com/@reegun/unsanitized-file-validation-leads-to-malicious-payload-download-via-office-binaries-202d02db7191

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -37,6 +37,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_wsl_lolbin.yml
+  - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: Child process from wsl.exe
 Resources:
   - Link: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules


### PR DESCRIPTION
This PR primarily adds content for addressing detection info for LOLBINs (e.g. those available). The following has been added:

- Sigma field - Relevant rules were linked to the GitHub Sigma project that likely applied to the LOLBIN characteristics. There may be other relevant rules that can always be added. For some LOLBINs, a blank 'Sigma' field was added as a placeholder for a future community rule link. Other open-source rule sources that are published on git resources will be linked in the future accordingly by general source name.

- IOC field - This is the original field that was included in LOLBAS under Detection. The field is relevant if contextual information is provided . In this PR, IOC fields were updated, added, or removed (if irrelevant).

- BlockRule field - If a lolbin is explicitly mentioned in the WDAC Block Rules, there is a link to the resource.

- Blog field - This is an experimental field that was added to a single lolbin. Ideally, this will link to a resource (e.g. blog post) that provides insight into a particular detection (engineering) technique/methodology.  The field name may be worth changing to account for other related resources that are not necessarily blog posts (e.g. WriteUp)

Additionally, several content updates were creates that included the following:

- General syntax/quality updates were fixed throughout (e.g. code fields)
- dfshim.dll was added to oslibraries. The content of dfsvc.exe was copied with minor updates.
- sc.exe was updated to reflect service modification tradecraft.