### PR TITLE
Changed tid to better match use case.

### DIFF
--- a/yml/OSBinaries/Wuauclt.yml
+++ b/yml/OSBinaries/Wuauclt.yml
@@ -4,7 +4,7 @@ Description: Windows Update Client
 Author: 'David Middlehurst'
 Created: 2020-09-23
 Commands:
-  - Command: wuauclt.exe /UpdateDeploymentProvider <Full_Path_To_DLL> /RunHandlerComServer
+  - Command: wuauclt.exe /UpdateDeploymentProvider Full_Path_To_DLL /RunHandlerComServer
     Description: Full_Path_To_DLL would be the abosolute path to .DLL file and would execute code on attach.
     Usecase: Execute dll via attach/detach methods
     Category: Execute

--- a/yml/OSBinaries/Wuauclt.yml
+++ b/yml/OSBinaries/Wuauclt.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Execute dll via attach/detach methods
     Category: Execute
     Privileges: User
-    MitreID: T1218.011
+    MitreID: T1218
     OperatingSystem: Windows 10
 Full_Path:
   - Path: C:\Windows\System32\wuauclt.exe


### PR DESCRIPTION
T1218.011 Signed Binary Proxy Execution: Rundll32 does not match this particular binary as it is not an OSLibrary. 
It's far more accurate to move it to T1218.