### PR TITLE
.NET Core createdump.exe

### DIFF
--- a/yml/OtherMSBinaries/Createdump.yml
+++ b/yml/OtherMSBinaries/Createdump.yml
@@ -1,11 +1,11 @@
 ---
 Name: Createdump.exe
-Description: Process dump creation utility included with .NET Core.
+Description: Microsoft .NET Runtime Crash Dump Generator (included in .NET Core)
 Author: Daniel Santos
 Created: 2022-08-05
 Commands:
-  - Command: createdump.exe -n -f %TEMP%\dump.dmp [PID]
-    Description: Dump process by PID and create a minidump file. If not specified, the file is created as '%TEMP%\dump.%p.dmp' where %p is the PID of the target process.
+  - Command: createdump.exe -n -f dump.dmp [PID]
+    Description: Dump process by PID and create a minidump file. If "-f dump.dmp" is not specified, the file is created as '%TEMP%\dump.%p.dmp' where %p is the PID of the target process.
     Usecase: Dump process memory contents using PID.
     Category: Dump
     Privileges: SYSTEM

--- a/yml/OtherMSBinaries/Createdump.yml
+++ b/yml/OtherMSBinaries/Createdump.yml
@@ -19,5 +19,5 @@ Resources:
   - Link: https://twitter.com/bopin2020/status/1366400799199272960
   - Link: https://docs.microsoft.com/en-us/troubleshoot/developer/webapps/aspnetcore/practice-troubleshoot-linux/lab-1-3-capture-core-crash-dumps
 Acknowledgement:
-  - Name: bopin
+  - Person: bopin
     Handle: '@bopin2020'

--- a/yml/OtherMSBinaries/Createdump.yml
+++ b/yml/OtherMSBinaries/Createdump.yml
@@ -1,25 +1,23 @@
 ---
-Name: Sqldumper.exe
+Name: Createdump.exe
 Description: Process dump creation utility included with .NET Core.
-Author: 'Daniel Santos'
+Author: Daniel Santos
 Created: 2022-08-05
 Commands:
   - Command: createdump.exe -n -f %TEMP%\dump.dmp [PID]
     Description: Dump process by PID and create a minidump file. If not specified, the file is created as '%TEMP%\dump.%p.dmp' where %p is the PID of the target process.
-    Usecase: Dump process using PID.
+    Usecase: Dump process memory contents using PID.
     Category: Dump
     Privileges: Administrator
     MitreID: T1003
-    OperatingSystem: Windows
+    OperatingSystem: Windows 10, Windows 11
 Full_Path:
   - Path: C:\Program Files\dotnet\shared\Microsoft.NETCore.App\*\createdump.exe
-Code_Sample:
-  - Code:
 Detection:
-  - IOC: createdump.exe process with a command line containing the lsass.exe process id.
+  - IOC: createdump.exe process with a command line containing the lsass.exe process id
 Resources:
   - Link: https://twitter.com/bopin2020/status/1366400799199272960
   - Link: https://docs.microsoft.com/en-us/troubleshoot/developer/webapps/aspnetcore/practice-troubleshoot-linux/lab-1-3-capture-core-crash-dumps
 Acknowledgement:
-  - Handle: '@bopin2020'
----
+  - Name: bopin
+    Handle: '@bopin2020'

--- a/yml/OtherMSBinaries/Createdump.yml
+++ b/yml/OtherMSBinaries/Createdump.yml
@@ -8,7 +8,7 @@ Commands:
     Description: Dump process by PID and create a minidump file. If not specified, the file is created as '%TEMP%\dump.%p.dmp' where %p is the PID of the target process.
     Usecase: Dump process memory contents using PID.
     Category: Dump
-    Privileges: Administrator
+    Privileges: SYSTEM
     MitreID: T1003
     OperatingSystem: Windows 10, Windows 11
 Full_Path:

--- a/yml/OtherMSBinaries/Createdump.yml
+++ b/yml/OtherMSBinaries/Createdump.yml
@@ -1,0 +1,25 @@
+---
+Name: Sqldumper.exe
+Description: Process dump creation utility included with .NET Core.
+Author: 'Daniel Santos'
+Created: 2022-08-05
+Commands:
+  - Command: createdump.exe -n -f %TEMP%\dump.dmp [PID]
+    Description: Dump process by PID and create a minidump file. If not specified, the file is created as '%TEMP%\dump.%p.dmp' where %p is the PID of the target process.
+    Usecase: Dump process using PID.
+    Category: Dump
+    Privileges: Administrator
+    MitreID: T1003
+    OperatingSystem: Windows
+Full_Path:
+  - Path: C:\Program Files\dotnet\shared\Microsoft.NETCore.App\*\createdump.exe
+Code_Sample:
+  - Code:
+Detection:
+  - IOC: createdump.exe process with a command line containing the lsass.exe process id.
+Resources:
+  - Link: https://twitter.com/bopin2020/status/1366400799199272960
+  - Link: https://docs.microsoft.com/en-us/troubleshoot/developer/webapps/aspnetcore/practice-troubleshoot-linux/lab-1-3-capture-core-crash-dumps
+Acknowledgement:
+  - Handle: '@bopin2020'
+---


### PR DESCRIPTION
The createdump.exe utility is a Microsoft signed binary provided as part of the .NET Core toolset.  It can be used to create standard process minidumps.