### PR TITLE
Optional aliases introduction to YAML Template

### DIFF
--- a/YML-Template.yml
+++ b/YML-Template.yml
@@ -2,7 +2,7 @@
 Name: Binary.exe
 Description: Something general about the binary
 Aliases:  # Optional field if any common aliases exist of the binary with nearly the same functionality,
-  - Binary64.exe  # but for example, is built for different architecture.
+  - Alias: Binary64.exe  # but for example, is built for different architecture.
 Author: The name of the person that created this file
 Created: YYYY-MM-DD (date the person created this file)
 Commands:

--- a/YML-Template.yml
+++ b/YML-Template.yml
@@ -2,7 +2,7 @@
 Name: Binary.exe
 Description: Something general about the binary
 Aliases:  # Optional field if any common aliases exist of the binary with nearly the same functionality,
-  - Binary64.exe  # Think `netcat` and `nc` or `procdump.exe` and `procdump64.exe`.
+  - Binary64.exe  # but for example, is built for different architecture.
 Author: The name of the person that created this file
 Created: YYYY-MM-DD (date the person created this file)
 Commands:

--- a/YML-Template.yml
+++ b/YML-Template.yml
@@ -1,8 +1,8 @@
 ---
 Name: Binary.exe
 Description: Something general about the binary
-aliases:  # Optional field if any common aliases exist of the binary with nearly the same functionality 
-  - Binary64.exe  # Think `netcat` and `nc` or `procdump.exe` and `procdump64.exe`
+Aliases:  # Optional field if any common aliases exist of the binary with nearly the same functionality,
+  - Binary64.exe  # Think `netcat` and `nc` or `procdump.exe` and `procdump64.exe`.
 Author: The name of the person that created this file
 Created: YYYY-MM-DD (date the person created this file)
 Commands:

--- a/YML-Template.yml
+++ b/YML-Template.yml
@@ -1,6 +1,8 @@
 ---
 Name: Binary.exe
 Description: Something general about the binary
+aliases:
+  - Binary64.exe
 Author: The name of the person that created this file
 Created: YYYY-MM-DD (date the person created this file)
 Commands:

--- a/YML-Template.yml
+++ b/YML-Template.yml
@@ -1,8 +1,8 @@
 ---
 Name: Binary.exe
 Description: Something general about the binary
-aliases:
-  - Binary64.exe
+aliases:  # Optional field if any common aliases exist of the binary with nearly the same functionality 
+  - Binary64.exe  # Think `netcat` and `nc` or `procdump.exe` and `procdump64.exe`
 Author: The name of the person that created this file
 Created: YYYY-MM-DD (date the person created this file)
 Commands:

--- a/yml/OtherMSBinaries/Procdump.yml
+++ b/yml/OtherMSBinaries/Procdump.yml
@@ -2,7 +2,7 @@
 Name: Procdump.exe
 Description: SysInternals Memory Dump Tool
 Aliases:
-  Alias: Procdump64.exe
+  - Alias: Procdump64.exe
 Author: 'Alfie Champion (@ajpc500)'
 Created: '2020-10-14'
 Commands:

--- a/yml/OtherMSBinaries/Procdump.yml
+++ b/yml/OtherMSBinaries/Procdump.yml
@@ -1,8 +1,10 @@
 ---
-Name: Procdump(64).exe
+Name: Procdump.exe
 Description: SysInternals Memory Dump Tool
 Author: 'Alfie Champion (@ajpc500)'
 Created: '2020-10-14'
+Aliases:
+  - Procdump64.exe
 Commands:
   - Command: procdump.exe -md calc.dll explorer.exe
     Description: Loads calc.dll where DLL is configured with a 'MiniDumpCallbackRoutine' exported function. Valid process must be provided as dump still created.


### PR DESCRIPTION
### Rationale

I wrote some python tooling that processes the LOLBAS project YAML files for query and reporting purposes and I ran in to the issue that [`procdump(64).exe` ](https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OtherMSBinaries/Procdump.yml#L2)doesn't actually match any real binaries, but `procdump.exe` and `procdump64.exe` do. 

My initial reaction was to add an aliases field that list function-identical common binaries, as the rest of the documentation remains correct. Other solutions, such as accepting regex or globs seem overkill. 

**PS**: I'm very grateful for all the work by all contributors of the LOLBAS project. I rely on this project on a regular basis. 
I also understand the pain of changing data formats and documentation, especially if it is not backwards compatible. 
My use case for the LOLBAS project might also overstep the project's purpose, so there's that as well. 
The time spent on this Pull Request is purposely low on my end, so I have no emotional attachment to it, if it is rejected ;-). 
