### PR TITLE
Add Splunk detections to LOLBAS

### DIFF
--- a/yml/OSBinaries/At.yml
+++ b/yml/OSBinaries/At.yml
@@ -20,6 +20,9 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_at_interactive_execution.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/network/zeek/zeek_smb_converted_win_atsvc_task.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/builtin/security/win_security_atsvc_task.yml
+  - Splunk: https://research.splunk.com/endpoint/7bc20606-5f40-11ec-a586-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/4be54858-432f-11ec-8209-3e22fbd008af/
+  - Splunk: https://research.splunk.com/endpoint/bf0a378e-5f3c-11ec-a6de-acde48001122/
   - IOC: C:\Windows\System32\Tasks\At1 (substitute 1 with subsequent number of at job)
   - IOC: C:\Windows\Tasks\At1.job
   - IOC: Registry Key - Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\At1.

--- a/yml/OSBinaries/Bitsadmin.yml
+++ b/yml/OSBinaries/Bitsadmin.yml
@@ -40,6 +40,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/web/proxy_generic/proxy_ua_bitsadmin_susp_tld.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_bitsadmin_potential_persistence.yml
   - Splunk: https://github.com/splunk/security_content/blob/3f77e24974239fcb7a339080a1a483e6bad84a82/detections/endpoint/bitsadmin_download_file.yml
+  - Splunk: https://research.splunk.com/endpoint/80630ff4-8e4c-11eb-aab5-acde48001122/
   - IOC: Child process from bitsadmin.exe
   - IOC: bitsadmin creates new files
   - IOC: bitsadmin adds data to alternate data stream

--- a/yml/OSBinaries/Certutil.yml
+++ b/yml/OSBinaries/Certutil.yml
@@ -67,6 +67,9 @@ Detection:
   - Splunk: https://github.com/splunk/security_content/blob/3f77e24974239fcb7a339080a1a483e6bad84a82/detections/endpoint/certutil_download_with_urlcache_and_split_arguments.yml
   - Splunk: https://github.com/splunk/security_content/blob/3f77e24974239fcb7a339080a1a483e6bad84a82/detections/endpoint/certutil_download_with_verifyctl_and_split_arguments.yml
   - Splunk: https://github.com/splunk/security_content/blob/3f77e24974239fcb7a339080a1a483e6bad84a82/detections/endpoint/certutil_with_decode_argument.yml
+  - Splunk: https://research.splunk.com/endpoint/801ad9e4-8bfb-11eb-8b31-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/415b4306-8bfb-11eb-85c4-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/bfe94226-8c10-11eb-a4b3-acde48001122/
   - IOC: Certutil.exe creating new files on disk
   - IOC: Useragent Microsoft-CryptoAPI/10.0
   - IOC: Useragent CertUtil URL Agent

--- a/yml/OSBinaries/Cmd.yml
+++ b/yml/OSBinaries/Cmd.yml
@@ -39,6 +39,10 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_susp_alternate_data_streams.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_ads_file_creation.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_unusual_dir_ads.toml
+  - Splunk: https://research.splunk.com/endpoint/dcfd6b40-42f9-469d-a433-2e53f7486664/
+  - Splunk: https://research.splunk.com/endpoint/54a6ed00-3256-11ec-b031-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/eb277ba0-b96b-11eb-b00e-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/b89919ed-fe5f-492c-b139-95dbb162039e/
   - IOC: cmd.exe executing files from alternate data streams.
   - IOC: cmd.exe creating/modifying file contents in an alternate data stream.
 Resources:

--- a/yml/OSBinaries/Cmstp.yml
+++ b/yml/OSBinaries/Cmstp.yml
@@ -42,6 +42,7 @@ Detection:
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/cmlua_or_cmstplua_uac_bypass.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
+  - Splunk: https://research.splunk.com/endpoint/f87b5062-b405-11eb-a889-acde48001122/
   - IOC: Execution of cmstp.exe without a VPN use case is suspicious
   - IOC: DotNet CLR libraries loaded into cmstp.exe
   - IOC: DotNet CLR Usage Log - cmstp.exe.log

--- a/yml/OSBinaries/Control.yml
+++ b/yml/OSBinaries/Control.yml
@@ -31,6 +31,7 @@ Detection:
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/0875c1e4c4370ab9fbf453c8160bb5abc8ad95e7/rules/windows/defense_evasion_execution_control_panel_suspicious_args.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_unusual_dir_ads.toml
+  - Splunk: https://research.splunk.com/endpoint/10423ac4-10c9-11ec-8dc4-acde48001122/
   - IOC: Control.exe executing files from alternate data streams
   - IOC: Control.exe executing library file without cpl extension
   - IOC: Suspicious network connections from control.exe

--- a/yml/OSBinaries/Eventvwr.yml
+++ b/yml/OSBinaries/Eventvwr.yml
@@ -35,6 +35,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/197615345b927682ab7ad7fa3c5f5bb2ed911eed/rules/windows/file/file_event/file_event_win_uac_bypass_eventvwr.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/d31ea6253ea40789b1fc49ade79b7ec92154d12a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/eventvwr_uac_bypass.yml
+  - Splunk: https://research.splunk.com/endpoint/9cf8fe08-7ad8-11eb-9819-acde48001122/
   - IOC: eventvwr.exe launching child process other than mmc.exe
   - IOC: Creation or modification of the registry value HKCU\Software\Classes\mscfile\shell\open\command
 Resources:

--- a/yml/OSBinaries/Forfiles.yml
+++ b/yml/OSBinaries/Forfiles.yml
@@ -27,6 +27,8 @@ Full_Path:
   - Path: C:\Windows\SysWOW64\forfiles.exe
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_lolbin_forfiles.yml
+  - Splunk: https://research.splunk.com/endpoint/bfdaabe7-3db8-48c5-80c1-220f9b8f22be/
+  - Splunk: https://research.splunk.com/endpoint/1fdf31c9-ff4d-4c48-b799-0e8666e08787/
 Resources:
   - Link: https://twitter.com/vector_sec/status/896049052642533376
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Installutil.yml
+++ b/yml/OSBinaries/Installutil.yml
@@ -43,6 +43,12 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_lolbin_installutil_download.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/cc241c0b5ec590d76cb88ec638d3cc37f68b5d50/rules/windows/defense_evasion_installutil_beacon.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+  - Splunk: https://research.splunk.com/endpoint/4fbf9270-43da-11ec-9486-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/dcf74b22-7933-11ec-857c-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/cfa7b9ac-43f0-11ec-9b48-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/ccfeddec-43ec-11ec-b494-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/1a52c836-43ef-11ec-a36c-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/28e06670-43df-11ec-a569-acde48001122/
 Resources:
   - Link: https://pentestlab.blog/2017/05/08/applocker-bypass-installutil/
   - Link: https://evi1cg.me/archives/AppLocker_Bypass_Techniques.html#menu_index_12

--- a/yml/OSBinaries/Mavinject.yml
+++ b/yml/OSBinaries/Mavinject.yml
@@ -27,6 +27,7 @@ Full_Path:
   - Path: C:\Windows\SysWOW64\mavinject.exe
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_lolbin_mavinject_process_injection.yml
+  - Splunk: https://research.splunk.com/endpoint/ccf4b61b-1b26-4f2e-a089-f2009c569c57/
   - IOC: mavinject.exe should not run unless APP-v is in use on the workstation
 Resources:
   - Link: https://twitter.com/gN3mes1s/status/941315826107510784

--- a/yml/OSBinaries/Microsoft.Workflow.Compiler.yml
+++ b/yml/OSBinaries/Microsoft.Workflow.Compiler.yml
@@ -41,6 +41,8 @@ Detection:
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - Splunk: https://research.splunk.com/endpoint/9bbc62e8-55d8-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/f0db4464-55d9-11eb-ae93-0242ac130002/
   - IOC: Microsoft.Workflow.Compiler.exe would not normally be run on workstations.
   - IOC: The presence of csc.exe or vbc.exe as child processes of Microsoft.Workflow.Compiler.exe
   - IOC: Presence of "<CompilerInput" in a text file.

--- a/yml/OSBinaries/Mmc.yml
+++ b/yml/OSBinaries/Mmc.yml
@@ -37,6 +37,8 @@ Full_Path:
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/c04bef2fbbe8beff6c7620d5d7ea6872dbe7acba/rules/windows/process_creation/proc_creation_win_mmc_susp_child_process.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/c04bef2fbbe8beff6c7620d5d7ea6872dbe7acba/rules/windows/file/file_event/file_event_win_uac_bypass_dotnet_profiler.yml
+  - Splunk: https://research.splunk.com/endpoint/7f04349c-e30d-11eb-bc7f-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/f6601940-4c74-11ec-b9b7-3e22fbd008af/
 Resources:
   - Link: https://bohops.com/2018/08/18/abusing-the-com-registry-structure-part-2-loading-techniques-for-evasion-and-persistence/
   - Link: https://offsec.almond.consulting/UAC-bypass-dotnet.html

--- a/yml/OSBinaries/Msbuild.yml
+++ b/yml/OSBinaries/Msbuild.yml
@@ -70,6 +70,10 @@ Detection:
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - Splunk: https://research.splunk.com/endpoint/f5198224-551c-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/213b3148-24ea-11ec-93a2-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/4006adac-5937-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/a115fba6-5514-11eb-ae93-0242ac130002/
   - IOC: Msbuild.exe should not normally be executed on workstations
 Resources:
   - Link: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1127/T1127.md

--- a/yml/OSBinaries/Msdt.yml
+++ b/yml/OSBinaries/Msdt.yml
@@ -43,6 +43,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6199a703221a98ae6ad343c79c558da375203e4e/rules/windows/process_creation/proc_creation_win_lolbin_msdt_answer_file.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/c04bef2fbbe8beff6c7620d5d7ea6872dbe7acba/rules/windows/process_creation/proc_creation_win_msdt_arbitrary_command_execution.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+  - Splunk: https://research.splunk.com/endpoint/e1d5145f-38fe-42b9-a5d5-457796715f97/
 Resources:
   - Link: https://web.archive.org/web/20160322142537/https://cybersyndicates.com/2015/10/a-no-bull-guide-to-malicious-windows-trouble-shooting-packs-and-application-whitelist-bypass/
   - Link: https://oddvar.moe/2017/12/21/applocker-case-study-how-insecure-is-it-really-part-2/

--- a/yml/OSBinaries/Mshta.yml
+++ b/yml/OSBinaries/Mshta.yml
@@ -71,6 +71,13 @@ Detection:
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/suspicious_mshta_child_process.yml
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/detect_mshta_url_in_command_line.yml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - Splunk: https://research.splunk.com/endpoint/a0873b32-5b68-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/8f45fcf0-5b68-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/9b3af1e6-5b68-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/60023bb6-5500-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/4d33a488-5b5f-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/4aa5d062-e893-11eb-9eb2-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/e13ceade-b673-4d34-adc4-4d9c01729753/
   - IOC: mshta.exe executing raw or obfuscated script within the command-line
   - IOC: General usage of HTA file
   - IOC: msthta.exe network connection to Internet/WWW resource

--- a/yml/OSBinaries/Msiexec.yml
+++ b/yml/OSBinaries/Msiexec.yml
@@ -62,6 +62,12 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/c04bef2fbbe8beff6c7620d5d7ea6872dbe7acba/rules/windows/process_creation/proc_creation_win_msiexec_masquerading.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/uninstall_app_using_msiexec.yml
+  - Splunk: https://research.splunk.com/endpoint/e9d05aa2-32f0-411b-930c-5b8ca5c4fcee/
+  - Splunk: https://research.splunk.com/endpoint/1fca2b28-f922-11eb-b2dd-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/827409a1-5393-4d8d-8da4-bbb297c262a7/
+  - Splunk: https://research.splunk.com/endpoint/fdb59aef-d88f-4909-8369-ec2afbd2c398/
+  - Splunk: https://research.splunk.com/endpoint/6aa49ff2-3c92-4586-83e0-d83eb693dfda/
+  - Splunk: https://research.splunk.com/endpoint/a27db3c5-1a9a-46df-a577-765d3f1a3c24/
   - IOC: msiexec.exe retrieving files from Internet
 Resources:
   - Link: https://pentestlab.blog/2017/06/16/applocker-bypass-msiexec/

--- a/yml/OSBinaries/Netsh.yml
+++ b/yml/OSBinaries/Netsh.yml
@@ -20,6 +20,9 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/c04bef2fbbe8beff6c7620d5d7ea6872dbe7acba/rules/windows/process_creation/proc_creation_win_netsh_helper_dll_persistence.yml
   - Splunk: https://github.com/splunk/security_content/blob/2b87b26bdc2a84b65b1355ffbd5174bdbdb1879c/detections/endpoint/processes_launching_netsh.yml
   - Splunk: https://github.com/splunk/security_content/blob/08ed88bd88259c03c771c30170d2934ed0a8f878/detections/deprecated/processes_created_by_netsh.yml
+  - Splunk: https://research.splunk.com/endpoint/7bc20606-5f40-11ec-a586-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/4be54858-432f-11ec-8209-3e22fbd008af/
+  - Splunk: https://research.splunk.com/endpoint/bf0a378e-5f3c-11ec-a6de-acde48001122/
   - IOC: Netsh initiating a network connection
 Resources:
   - Link: https://freddiebarrsmith.com/trix/trix.html

--- a/yml/OSBinaries/Odbcconf.yml
+++ b/yml/OSBinaries/Odbcconf.yml
@@ -41,6 +41,9 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_odbcconf_response_file_susp.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+  - Splunk: https://research.splunk.com/endpoint/141e7fca-a9f0-40fd-a539-9aac8be41f1b/
+  - Splunk: https://research.splunk.com/endpoint/0562ad4b-fdaa-4882-b12f-7b8e0034cd72/
+  - Splunk: https://research.splunk.com/endpoint/1acafff9-1347-4b40-abae-f35aa4ba85c1/
 Resources:
   - Link: https://gist.github.com/NickTyrer/6ef02ce3fd623483137b45f65017352b
   - Link: https://github.com/woanware/application-restriction-bypasses

--- a/yml/OSBinaries/Pcalua.yml
+++ b/yml/OSBinaries/Pcalua.yml
@@ -36,6 +36,7 @@ Full_Path:
   - Path: C:\Windows\System32\pcalua.exe
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_lolbin_pcalua.yml
+  - Splunk: https://research.splunk.com/endpoint/3428ac18-a410-4823-816c-ce697d26f7a8/
 Resources:
   - Link: https://twitter.com/KyleHanslovan/status/912659279806640128
 Acknowledgement:

--- a/yml/OSBinaries/Rasautou.yml
+++ b/yml/OSBinaries/Rasautou.yml
@@ -17,6 +17,7 @@ Full_Path:
   - Path: C:\Windows\System32\rasautou.exe
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_rasautou_dll_execution.yml
+  - Splunk: https://research.splunk.com/endpoint/6f42b8be-8e96-11ec-ad5a-acde48001122/
   - IOC: rasautou.exe command line containing -d and -p
 Resources:
   - Link: https://github.com/fireeye/DueDLLigence

--- a/yml/OSBinaries/Reg.yml
+++ b/yml/OSBinaries/Reg.yml
@@ -27,6 +27,8 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/c04bef2fbbe8beff6c7620d5d7ea6872dbe7acba/rules/windows/process_creation/proc_creation_win_reg_dumping_sensitive_hives.yml
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/attempted_credential_dump_from_registry_via_reg_exe.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/f6421d8c534f295518a2c945f530e8afc4c8ad1b/rules/windows/credential_access_dump_registry_hives.toml
+  - Splunk: https://research.splunk.com/endpoint/e9fb4a59-c5fb-440a-9f24-191fbc6b2911/
+  - Splunk: https://research.splunk.com/endpoint/8bbb7d58-b360-11eb-ba21-acde48001122/
   - IOC: reg.exe writing to an ADS
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Regasm.yml
+++ b/yml/OSBinaries/Regasm.yml
@@ -32,6 +32,9 @@ Detection:
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
   - Splunk: https://github.com/splunk/security_content/blob/bc93e670f5dcb24e96fbe3664d6bcad92df5acad/docs/_stories/suspicious_regsvcs_regasm_activity.md
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/detect_regasm_with_network_connection.yml
+  - Splunk: https://research.splunk.com/endpoint/07921114-6db4-4e2e-ae58-3ea8a52ae93f/
+  - Splunk: https://research.splunk.com/endpoint/c3bc1430-04e7-4178-835f-047d8e6e97df/
+  - Splunk: https://research.splunk.com/endpoint/72170ec5-f7d2-42f5-aefb-2b8be6aad15f/
   - IOC: regasm.exe executing dll file
 Resources:
   - Link: https://pentestlab.blog/2017/05/19/applocker-bypass-regasm-and-regsvcs/

--- a/yml/OSBinaries/Regedit.yml
+++ b/yml/OSBinaries/Regedit.yml
@@ -22,6 +22,7 @@ Full_Path:
   - Path: C:\Windows\regedit.exe
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_regedit_import_keys_ads.yml
+  - Splunk: https://research.splunk.com/endpoint/6f42b8be-8e96-11ec-ad5a-acde48001122/
   - IOC: regedit.exe reading and writing to alternate data stream
   - IOC: regedit.exe should normally not be executed by end-users
 Resources:

--- a/yml/OSBinaries/Regsvcs.yml
+++ b/yml/OSBinaries/Regsvcs.yml
@@ -31,6 +31,9 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_lolbin_regasm.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/detect_regsvcs_with_network_connection.yml
+  - Splunk: https://research.splunk.com/endpoint/e3e7a1c0-f2b9-445c-8493-f30a63522d1a/
+  - Splunk: https://research.splunk.com/endpoint/6b74d578-a02e-4e94-a0d1-39440d0bf254/
+  - Splunk: https://research.splunk.com/endpoint/bc477b57-5c21-4ab6-9c33-668772e7f114/
 Resources:
   - Link: https://pentestlab.blog/2017/05/19/applocker-bypass-regasm-and-regsvcs/
   - Link: https://oddvar.moe/2017/12/13/applocker-case-study-how-insecure-is-it-really-part-1/

--- a/yml/OSBinaries/Regsvr32.yml
+++ b/yml/OSBinaries/Regsvr32.yml
@@ -75,6 +75,11 @@ Detection:
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_regsvr32_application_control_bypass.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+  - Splunk: https://research.splunk.com/endpoint/c9ef7dc4-eeaf-11eb-b2b6-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/62732736-6250-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/070e9b80-6252-11eb-ae93-0242ac130002/
+  - Splunk: https://research.splunk.com/endpoint/f421c250-24e7-11ec-bc43-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/7349a9e9-3cf6-4171-bb0c-75607a8dcd1a/
   - IOC: regsvr32.exe retrieving files from Internet
   - IOC: regsvr32.exe executing scriptlet (sct) files
   - IOC: DotNet CLR libraries loaded into regsvr32.exe

--- a/yml/OSBinaries/Rundll32.yml
+++ b/yml/OSBinaries/Rundll32.yml
@@ -57,6 +57,21 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/c04bef2fbbe8beff6c7620d5d7ea6872dbe7acba/rules/windows/network_connection/net_connection_win_rundll32_net_connections.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_rundll32_susp_activity.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/defense_evasion_unusual_network_connection_via_rundll32.toml
+  - Splunk: https://research.splunk.com/endpoint/e451bd16-e4c5-4109-8eb1-c4c6ecf048b4/
+  - Splunk: https://research.splunk.com/endpoint/61e7b44a-6088-4f26-b788-9a96ba13b37a/
+  - Splunk: https://research.splunk.com/endpoint/35307032-a12d-11eb-835f-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/fa90f372-f91d-11eb-816c-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/9319dda5-73f2-4d43-a85a-67ce961bddb7/
+  - Splunk: https://research.splunk.com/endpoint/1adffe86-10c3-11ec-8ce6-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/92d51712-ee29-11eb-b1ae-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
+  - Splunk: https://research.splunk.com/endpoint/c8e7ced0-10c5-11ec-8b03-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/bed761f8-ee29-11eb-8bf3-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/4aefadfe-9abd-4bf8-b3fd-867e9ef95bf8/
+  - Splunk: https://research.splunk.com/endpoint/6338266a-ee2a-11eb-bf68-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/f1483f5e-ee29-11eb-9d23-acde48001122/
+  - Splunk: https://research.splunk.com/endpoint/8c00a385-9b86-4ac0-8932-c9ec3713b159/
+  - Splunk: https://research.splunk.com/deprecated/7360137f-abad-473e-8189-acbdaa34d114/
   - IOC: Outbount Internet/network connections made from rundll32
   - IOC: Suspicious use of cmdline flags such as -sta
 Resources:

--- a/yml/OSBinaries/Schtasks.yml
+++ b/yml/OSBinaries/Schtasks.yml
@@ -29,6 +29,9 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/c04bef2fbbe8beff6c7620d5d7ea6872dbe7acba/rules/windows/process_creation/proc_creation_win_schtasks_creation.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/ef7548f04c4341e0d1a172810330d59453f46a21/rules/windows/persistence_local_scheduled_task_creation.toml
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/schtasks_scheduling_job_on_remote_system.yml
+  - Splunk: https://research.splunk.com/endpoint/1297fb80-f42a-4b4a-9c8a-88c066237cf6/
+  - Splunk: https://research.splunk.com/endpoint/1297fb80-f42a-4b4a-9c8a-88c066437cf6/
+  - Splunk: https://research.splunk.com/endpoint/41a0e58e-884c-11ec-9976-acde48001122/
   - IOC: Suspicious task creation events
 Resources:
   - Link: https://isc.sans.edu/forums/diary/Adding+Persistence+Via+Scheduled+Tasks/23633/

--- a/yml/OSBinaries/Syncappvpublishingserver.yml
+++ b/yml/OSBinaries/Syncappvpublishingserver.yml
@@ -20,6 +20,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/powershell/powershell_script/posh_ps_syncappvpublishingserver_exe.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/powershell/powershell_module/posh_pm_syncappvpublishingserver_exe.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_lolbin_syncappvpublishingserver_execute_psh.yml
+  - Splunk: https://research.splunk.com/endpoint/8dd73f89-682d-444c-8b41-8e679966ad3c/
   - IOC: SyncAppvPublishingServer.exe should never be in use unless App-V is deployed
 Resources:
   - Link: https://twitter.com/monoxgas/status/895045566090010624

--- a/yml/OSBinaries/Verclsid.yml
+++ b/yml/OSBinaries/Verclsid.yml
@@ -19,6 +19,7 @@ Full_Path:
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_verclsid_runs_com.yml
   - Splunk: https://github.com/splunk/security_content/blob/a1afa0fa605639cbef7d528dec46ce7c8112194a/detections/endpoint/verclsid_clsid_execution.yml
+  - Splunk: https://research.splunk.com/endpoint/61e9a56a-20fa-11ec-8ba3-acde48001122/
 Resources:
   - Link: https://gist.github.com/NickTyrer/0598b60112eaafe6d07789f7964290d5
   - Link: https://bohops.com/2018/08/18/abusing-the-com-registry-structure-part-2-loading-techniques-for-evasion-and-persistence/

--- a/yml/OSBinaries/Wsreset.yml
+++ b/yml/OSBinaries/Wsreset.yml
@@ -18,6 +18,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_uac_bypass_wsreset.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/registry/registry_event/registry_event_bypass_via_wsreset.yml#
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/wsreset_uac_bypass.yml
+  - Splunk: https://research.splunk.com/endpoint/8b5901bc-da63-11eb-be43-acde48001122/
   - IOC: wsreset.exe launching child process other than mmc.exe
   - IOC: Creation or modification of the registry value HKCU\Software\Classes\AppX82a6gwre4fdg3bt635tn5ctqjf8msdd2\Shell\open\command
   - IOC: Microsoft Defender Antivirus as Behavior:Win32/UACBypassExp.T!gen

--- a/yml/OSLibraries/Advpack.yml
+++ b/yml/OSLibraries/Advpack.yml
@@ -58,6 +58,7 @@ Code_Sample:
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_rundll32_susp_activity.yml
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_rundll32_application_control_bypass___advpack.yml
+  - Splunk: https://research.splunk.com/endpoint/4aefadfe-9abd-4bf8-b3fd-867e9ef95bf8/
 Resources:
   - Link: https://bohops.com/2018/02/26/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence/
   - Link: https://twitter.com/ItsReallyNick/status/967859147977850880

--- a/yml/OSLibraries/Setupapi.yml
+++ b/yml/OSLibraries/Setupapi.yml
@@ -34,6 +34,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_rundll32_setupapi_installhinfsection.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_rundll32_susp_activity.yml
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_rundll32_application_control_bypass___setupapi.yml
+  - Splunk: https://research.splunk.com/endpoint/61e7b44a-6088-4f26-b788-9a96ba13b37a/
 Resources:
   - Link: https://github.com/huntresslabs/evading-autoruns
   - Link: https://twitter.com/pabraeken/status/994742106852941825

--- a/yml/OSLibraries/Syssetup.yml
+++ b/yml/OSLibraries/Syssetup.yml
@@ -32,6 +32,7 @@ Code_Sample:
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_rundll32_susp_activity.yml
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_rundll32_application_control_bypass___syssetup.yml
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
 Resources:
   - Link: https://twitter.com/pabraeken/status/994392481927258113
   - Link: https://twitter.com/harr0ey/status/975350238184697857

--- a/yml/OSLibraries/comsvcs.yml
+++ b/yml/OSLibraries/comsvcs.yml
@@ -20,6 +20,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_access/proc_access_win_lsass_dump_comsvcs_dll.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/dump_lsass_via_comsvcs_dll.yml
+  - Splunk: https://research.splunk.com/endpoint/8943b567-f14d-4ee8-a0bb-2121d4ce3184/
 Resources:
   - Link: https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/
 Acknowledgement:

--- a/yml/OSScripts/CL_mutexverifiers.yml
+++ b/yml/OSScripts/CL_mutexverifiers.yml
@@ -21,6 +21,7 @@ Full_Path:
   - Path: C:\Windows\diagnostics\system\Speech\CL_Mutexverifiers.ps1
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_lolbin_cl_mutexverifiers.yml
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
 Resources:
   - Link: https://twitter.com/pabraeken/status/995111125447577600
 Acknowledgement:

--- a/yml/OSScripts/Cl_invocation.yml
+++ b/yml/OSScripts/Cl_invocation.yml
@@ -20,6 +20,7 @@ Full_Path:
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/process_creation/proc_creation_win_lolbin_cl_invocation.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/6312dd1d44d309608552105c334948f793e89f48/rules/windows/powershell/powershell_script/posh_ps_cl_invocation_lolscript.yml
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
 Acknowledgement:
   - Person: Jimmy
     Handle: '@bohops'

--- a/yml/OSScripts/Manage-bde.yml
+++ b/yml/OSScripts/Manage-bde.yml
@@ -26,6 +26,7 @@ Full_Path:
   - Path: C:\Windows\System32\manage-bde.wsf
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_lolbin_manage_bde.yml
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
   - IOC: Manage-bde.wsf should not be invoked by a standard user under normal situations
 Resources:
   - Link: https://gist.github.com/bohops/735edb7494fe1bd1010d67823842b712

--- a/yml/OSScripts/Pubprn.yml
+++ b/yml/OSScripts/Pubprn.yml
@@ -21,6 +21,7 @@ Code_Sample:
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - Sigma: https://github.com/SigmaHQ/sigma/blob/ff5102832031425f6eed011dd3a2e62653008c94/rules/windows/process_creation/proc_creation_win_lolbin_pubprn.yml
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
 Resources:
   - Link: https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/
   - Link: https://www.slideshare.net/enigma0x3/windows-operating-system-archaeology

--- a/yml/OSScripts/Syncappvpublishingserver.yml
+++ b/yml/OSScripts/Syncappvpublishingserver.yml
@@ -17,6 +17,8 @@ Full_Path:
   - Path: C:\Windows\System32\SyncAppvPublishingServer.vbs
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_lolbin_syncappvpublishingserver_vbs_execute_psh.yml
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
+  - Splunk: https://research.splunk.com/endpoint/8dd73f89-682d-444c-8b41-8e679966ad3c/
 Resources:
   - Link: https://twitter.com/monoxgas/status/895045566090010624
   - Link: https://twitter.com/subTee/status/855738126882316288

--- a/yml/OSScripts/Winrm.yml
+++ b/yml/OSScripts/Winrm.yml
@@ -44,6 +44,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_winrm_execution_via_scripting_api_winrm_vbs.yml
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/file/file_event/file_event_win_winrm_awl_bypass.yml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
 Resources:
   - Link: https://www.slideshare.net/enigma0x3/windows-operating-system-archaeology
   - Link: https://www.youtube.com/watch?v=3gz1QmiMhss

--- a/yml/OSScripts/pester.yml
+++ b/yml/OSScripts/pester.yml
@@ -26,6 +26,7 @@ Full_Path:
   - Path: c:\Program Files\WindowsPowerShell\Modules\Pester\<VERSION>\bin\Pester.bat
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_lolbin_pester_1.yml
+  - Splunk: https://research.splunk.com/endpoint/71b9bf37-cde1-45fb-b899-1b0aa6fa1183/
 Resources:
   - Link: https://twitter.com/Oddvarmoe/status/993383596244258816
   - Link: https://twitter.com/_st0pp3r_/status/1560072680887525378

--- a/yml/OtherMSBinaries/Dotnet.yml
+++ b/yml/OtherMSBinaries/Dotnet.yml
@@ -45,6 +45,7 @@ Full_Path:
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_lolbin_dotnet.yml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - Splunk: https://research.splunk.com/endpoint/fddf3b56-7933-11ec-98a6-acde48001122/
   - IOC: dotnet.exe spawned an unknown process
 Resources:
   - Link: https://twitter.com/_felamos/status/1204705548668555264

--- a/yml/OtherMSBinaries/Ntdsutil.yml
+++ b/yml/OtherMSBinaries/Ntdsutil.yml
@@ -17,6 +17,7 @@ Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_ntdsutil_usage.yml
   - Splunk: https://github.com/splunk/security_content/blob/2b87b26bdc2a84b65b1355ffbd5174bdbdb1879c/detections/endpoint/ntdsutil_export_ntds.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
+  - Splunk: https://research.splunk.com/endpoint/da63bc76-61ae-11eb-ae93-0242ac130002/
   - IOC: ntdsutil.exe with command line including "ifm"
 Resources:
   - Link: https://adsecurity.org/?p=2398#CreateIFM


### PR DESCRIPTION
Hello LOLBAS Team this PR does 2 major things:

1. adds a new script called `enrich_with_splunk.py` under `scripts/enrich_with_splunk.py` 
2. updates all the LOLBAS to include known Splunk Security Content detections for these LOLBAS under the detection reference. 

The script logic for matching which LOLBAS has a detection is somewhat simple, it uses the following heuristic:
1. looks if Splunk has detection matching the MITRE Technique ID of the Command 
2. If the Technique ID matches it checks if the LOLBAS is in the name of the Splunk search 
3. A URL is added to the Detection array to include the matching Splunk detection 

This can use a bit of testing and maybe a README but please give me any feedback you might have. 