### PR TITLE
Added fsi to dotnet.exe

### DIFF
--- a/yml/OtherMSBinaries/Dotnet.yml
+++ b/yml/OtherMSBinaries/Dotnet.yml
@@ -19,11 +19,11 @@ Commands:
     MitreID: T1218
     OperatingSystem: Windows 7 and up with .NET installed
   - Command: dotnet.exe fsi
-    Description: dotnet.exe will open a console which would allow the user to execute arbitrary f# commands
-    Usecase: Execute Arbitrary Code
+    Description: dotnet.exe will open a console which allows for the execution of arbitrary F# commands
+    Usecase: Execute arbitrary F# code
     Category: Execute
     Privileges: User
-    MitreID: T1218
+    MitreID: T1059
     OperatingSystem: Windows 10 and up with .NET SDK installed
   - Command: dotnet.exe msbuild [Path_TO_XML_CSPROJ]
     Description: dotnet.exe with msbuild (SDK Version) will execute unsigned code
@@ -31,7 +31,7 @@ Commands:
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218
-    OperatingSystem: Windows 10 with .NET Core installed
+    OperatingSystem: Windows 10 and up with .NET Core installed
 Full_Path:
   - Path: 'C:\Program Files\dotnet\dotnet.exe'
 Detection:

--- a/yml/OtherMSBinaries/Dotnet.yml
+++ b/yml/OtherMSBinaries/Dotnet.yml
@@ -18,6 +18,13 @@ Commands:
     Privileges: User
     MitreID: T1218
     OperatingSystem: Windows 7 and up with .NET installed
+  - Command: dotnet.exe fsi
+    Description: dotnet.exe will open a console which would allow the user to execute arbitrary f# commands
+    Usecase: Execute Arbitrary Code
+    Category: Execute
+    Privileges: User
+    MitreID: T1218
+    OperatingSystem: Windows 10 and up with .NET SDK installed
   - Command: dotnet.exe msbuild [Path_TO_XML_CSPROJ]
     Description: dotnet.exe with msbuild (SDK Version) will execute unsigned code
     Usecase: Execute code bypassing AWL
@@ -35,8 +42,11 @@ Resources:
   - Link: https://twitter.com/_felamos/status/1204705548668555264
   - Link: https://gist.github.com/bohops/3f645a7238d8022830ecf5511b3ecfbc
   - Link: https://bohops.com/2019/08/19/dotnet-core-a-vector-for-awl-bypass-defense-evasion/
+  - Link: https://learn.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/
 Acknowledgement:
   - Person: felamos
     Handle: '@_felamos'
   - Person: Jimmy
     Handle: '@bohops'
+  - Person: yamalon
+    Handle: '@mavinject'


### PR DESCRIPTION
Fsi allows the user to run arbitrary f# code.
Works on any os with .net core 3+ with .net SDK.

It might also work on windows 7 as it can work on .net core 2.2 (officially on .net core 3) but it's not well documented so I couldn't write it with confidence.