### PR TITLE
Changed links to sigma rules 

### DIFF
--- a/yml/HonorableMentions/GfxDownloadWrapper.yml
+++ b/yml/HonorableMentions/GfxDownloadWrapper.yml
@@ -169,7 +169,7 @@ Full_Path:
   - Path: c:\windows\system32\driverstore\filerepository\ki132869.inf_amd64_052eb72d070df60f\
   - Path: c:\windows\system32\driverstore\filerepository\kit126731.inf_amd64_1905c9d5f38631d9\
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_file_download_via_gfxdownloadwrapper.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20eee00933-a761-4cd0-be70-c42fe91731e7
   - IOC: Usually GfxDownloadWrapper downloads a JSON file from https://gameplayapi.intel.com.
 Resources:
   - Link: https://www.sothis.tech/author/jgalvez/

--- a/yml/OSBinaries/AppInstaller.yml
+++ b/yml/OSBinaries/AppInstaller.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.11.2521.0_x64__8wekyb3d8bbwe\AppInstaller.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/bdb00f403fd8ede0daa04449ad913200af9466ff/rules/windows/dns_query/win_dq_lobas_appinstaller.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207cff77e1-9663-46a3-8260-17f2e1aa9d0a
 Resources:
   - Link: https://twitter.com/notwhickey/status/1333900137232523264
 Acknowledgement:

--- a/yml/OSBinaries/Aspnet_Compiler.yml
+++ b/yml/OSBinaries/Aspnet_Compiler.yml
@@ -18,7 +18,7 @@ Code_Sample:
   - Code: https://github.com/ThunderGunExpress/BringYourOwnBuilder
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/960a03eaf480926ed8db464477335a713e9e6630/rules/windows/process_creation/win_pc_lobas_aspnet_compiler.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20a01b8329-5953-4f73-ae2d-aa01e1f35f00
 Resources:
   - Link: https://ijustwannared.team/2020/08/01/the-curious-case-of-aspnet_compiler-exe/
   - Link: https://docs.microsoft.com/en-us/dotnet/api/system.web.compilation.buildprovider.generatecode?view=netframework-4.8

--- a/yml/OSBinaries/At.yml
+++ b/yml/OSBinaries/At.yml
@@ -15,9 +15,9 @@ Full_Path:
   - Path: C:\WINDOWS\System32\At.exe
   - Path: C:\WINDOWS\SysWOW64\At.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_interactive_at.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/network/zeek/zeek_smb_converted_win_atsvc_task.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/builtin/win_atsvc_task.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2060fc936d-2eb0-4543-8a13-911c750a1dfc
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20dde85b37-40cd-4a94-b00c-0b8794f956b5
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20f6de6525-4509-495a-8a82-1f8b0ed73a00
   - IOC: C:\Windows\System32\Tasks\At1 (substitute 1 with subsequent number of at job)
   - IOC: C:\Windows\Tasks\At1.job
   - IOC: Registry Key - Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\At1.

--- a/yml/OSBinaries/Atbroker.yml
+++ b/yml/OSBinaries/Atbroker.yml
@@ -15,8 +15,8 @@ Full_Path:
   - Path: C:\Windows\System32\Atbroker.exe
   - Path: C:\Windows\SysWOW64\Atbroker.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/eb406ba36fc607986970c09e53058af412093647/rules/windows/process_creation/win_susp_atbroker.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/registry_event/sysmon_susp_atbroker_change.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20f24bcaea-0cd1-11eb-adc1-0242ac120002
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209577edbb-851f-4243-8c91-1d5b50c1a39b
   - IOC: Changes to HKCU\Software\Microsoft\Windows NT\CurrentVersion\Accessibility\Configuration
   - IOC: Changes to HKLM\Software\Microsoft\Windows NT\CurrentVersion\Accessibility\ATs
   - IOC: Unknown AT starting C:\Windows\System32\ATBroker.exe /start malware

--- a/yml/OSBinaries/Bash.yml
+++ b/yml/OSBinaries/Bash.yml
@@ -39,7 +39,7 @@ Code_Sample:
   - Code:
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/960a03eaf480926ed8db464477335a713e9e6630/rules/windows/process_creation/win_pc_lobas_bash.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%205edc2273-c26f-406c-83f3-f4d948e740dd
   - IOC: Child process from bash.exe
 Resources:
   - Link: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules

--- a/yml/OSBinaries/Bitsadmin.yml
+++ b/yml/OSBinaries/Bitsadmin.yml
@@ -38,9 +38,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/90ca1a8ad2e5c96d09a9ae4ff92483a2110d49ff/rules/windows/process_creation/win_process_creation_bitsadmin_download.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/abcaf00aeef3769aa2a6f66f7fb6537b867c1691/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/e40b8592544721c689f8ae96477ea1218e4c7a05/rules/windows/process_creation/win_monitoring_for_persistence_via_bits.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d059842b-6b9d-4ed1-b5c3-5b89143c6ede
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209eb68894-7476-4cd6-8752-23b51f5883a7
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b9cbbc17-d00d-4e3d-a827-b06d03d2380d
   - Splunk: https://github.com/splunk/security_content/blob/3f77e24974239fcb7a339080a1a483e6bad84a82/detections/endpoint/bitsadmin_download_file.yml
   - IOC: Child process from bitsadmin.exe
   - IOC: bitsadmin creates new files

--- a/yml/OSBinaries/Certoc.yml
+++ b/yml/OSBinaries/Certoc.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/406f10b583469f7f7c245ff41002f75902693b7d/rules/windows/process_creation/process_creation_certoc_execution.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20242301bc-f92f-4476-8718-78004a6efd9f
   - IOC: Process creation with given parameter
   - IOC: Unsigned DLL load via certoc.exe
   - IOC: Network connection via certoc.exe

--- a/yml/OSBinaries/Certreq.yml
+++ b/yml/OSBinaries/Certreq.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/eb8c9c046b86e7d412bdcc3235693fa1c00f70d6/rules/windows/process_creation/win_susp_certreq_download.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204480827a-9799-4232-b2c4-ccc6c4e9e12b
   - IOC: certreq creates new files
   - IOC: certreq makes POST requests
 Resources:

--- a/yml/OSBinaries/Certutil.yml
+++ b/yml/OSBinaries/Certutil.yml
@@ -52,9 +52,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0fcbce993288f993e626494a50dad15fc26c8a0c/rules/windows/process_creation/win_susp_certutil_command.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_certutil_encode.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/e9260679d4aeae7f696001c5b14d318d31c8f076/rules/windows/process_creation/process_creation_root_certificate_installed.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e011a729-98a6-4139-b5c4-bf6f6dd8239a
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e62a9f0c-ca1e-46b2-85d5-a6da77f86d1a
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2046591fae-7a4c-46ea-aec3-dff5e6d785dc
   - Elastic: https://github.com/elastic/detection-rules/blob/4a11ef9514938e7a7e32cf5f379e975cebf5aed3/rules/windows/defense_evasion_suspicious_certutil_commands.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/command_and_control_certutil_network_connection.toml
   - Splunk: https://github.com/splunk/security_content/blob/3f77e24974239fcb7a339080a1a483e6bad84a82/detections/endpoint/certutil_download_with_urlcache_and_split_arguments.yml

--- a/yml/OSBinaries/Cmd.yml
+++ b/yml/OSBinaries/Cmd.yml
@@ -36,7 +36,7 @@ Full_Path:
   - Path: C:\Windows\System32\cmd.exe
   - Path: C:\Windows\SysWOW64\cmd.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/688df3405afd778d63a2ea36a084344a2052848c/rules/windows/process_creation/process_creation_alternate_data_streams.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207f43c430-5001-4f8b-aaa9-c3b88f18fa5c
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_ads_file_creation.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_unusual_dir_ads.toml
   - IOC: cmd.exe executing files from alternate data streams.

--- a/yml/OSBinaries/Cmdkey.yml
+++ b/yml/OSBinaries/Cmdkey.yml
@@ -15,7 +15,7 @@ Full_Path:
   - Path: C:\Windows\System32\cmdkey.exe
   - Path: C:\Windows\SysWOW64\cmdkey.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/c3c152d457773454f67895008a1abde823be0755/rules/windows/process_creation/win_cmdkey_recon.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2007f8bdc2-c9b3-472a-9817-5a670b872f53
 Resources:
   - Link: https://www.peew.pw/blog/2017/11/26/exploring-cmdkey-an-edge-case-for-privilege-escalation
   - Link: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmdkey

--- a/yml/OSBinaries/Cmdl32.yml
+++ b/yml/OSBinaries/Cmdl32.yml
@@ -15,7 +15,7 @@ Full_Path:
   - Path: C:\Windows\System32\cmdl32.exe
   - Path: C:\Windows\SysWOW64\cmdl32.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/3416db73016f25ce115f5597fe74320d2428db66/rules/windows/process_creation/win_pc_susp_cmdl32_lolbas.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20f37aba28-a9e6-4045-882c-d5004043b337
   - IOC: Reports of downloading from suspicious URLs in %TMP%\config.log
   - IOC: Useragent Microsoft(R) Connection Manager Vpn File Update
 Resources:

--- a/yml/OSBinaries/Cmstp.yml
+++ b/yml/OSBinaries/Cmstp.yml
@@ -22,8 +22,8 @@ Full_Path:
   - Path: C:\Windows\System32\cmstp.exe
   - Path: C:\Windows\SysWOW64\cmstp.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6d0d58dfe240f7ef46e7da928c0b65223a46c3b2/rules/windows/process_creation/sysmon_cmstp_execution_by_creation.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_uac_cmstp.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207d4cdc5a-0076-40ca-aac8-f7e714570e47
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e66779cc-383e-4224-a3a4-267eeb585c40
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/cmlua_or_cmstplua_uac_bypass.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml

--- a/yml/OSBinaries/ConfigSecurityPolicy.yml
+++ b/yml/OSBinaries/ConfigSecurityPolicy.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/5e57e476c29980800dcc88a7a001ddb75d21a58b/rules/windows/process_creation/win_pc_lolbas_configsecuritypolicy.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%201f0f6176-6482-4027-b151-00071af39d7e
   - IOC: ConfigSecurityPolicy storing data into alternate data streams.
   - IOC: Preventing/Detecting ConfigSecurityPolicy with non-RFC1918 addresses by Network IPS/IDS.
   - IOC: Monitor process creation for non-SYSTEM and non-LOCAL SERVICE accounts launching ConfigSecurityPolicy.exe.

--- a/yml/OSBinaries/Conhost.yml
+++ b/yml/OSBinaries/Conhost.yml
@@ -22,7 +22,7 @@ Full_Path:
   - Path: c:\windows\system32\conhost.exe
 Detection:
   - IOC: conhost.exe spawning unexpected processes
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/bea6f18d350d9c9fdc067f93dde0e9b11cc22dc2/rules/windows/process_creation/proc_creation_win_susp_conhost.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207dc2dedd-7603-461a-bc13-15803d132355
 Resources:
   - Link: https://www.hexacorn.com/blog/2020/05/25/how-to-con-your-host/
   - Link: https://twitter.com/Wietze/status/1511397781159751680

--- a/yml/OSBinaries/Control.yml
+++ b/yml/OSBinaries/Control.yml
@@ -17,8 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/e8b633f54fce88e82b1c3d5e7c7bfa7d3d0beee7/rules/windows/process_creation/win_susp_control_cve_2021_40444.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_control_dll_load.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20894397c6-da03-425c-a589-3d09e7d1f750
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d7eb979b-c2b5-4a6f-a3a7-c87ce6763819
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/0875c1e4c4370ab9fbf453c8160bb5abc8ad95e7/rules/windows/defense_evasion_execution_control_panel_suspicious_args.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_unusual_dir_ads.toml

--- a/yml/OSBinaries/Csc.yml
+++ b/yml/OSBinaries/Csc.yml
@@ -24,8 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_csc.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_csc_folder.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b730a276-6b63-41b8-bcf8-55930c8fc6ee
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20dcaa3f04-70c3-427a-80b4-b870d73c94c4
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
   - IOC: Csc.exe should normally not run as System account unless it is used for development.

--- a/yml/OSBinaries/Cscript.yml
+++ b/yml/OSBinaries/Cscript.yml
@@ -17,8 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_script_execution.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%201e33157c-53b1-41ad-bbcc-780b80b58288
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e4b63079-6198-405c-abd7-3fe8b0ce3263
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_unusual_dir_ads.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/cc241c0b5ec590d76cb88ec638d3cc37f68b5d50/rules/windows/command_and_control_remote_file_copy_scripts.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml

--- a/yml/OSBinaries/CustomShellHost.yml
+++ b/yml/OSBinaries/CustomShellHost.yml
@@ -15,7 +15,7 @@ Full_Path:
   - Path: C:\Windows\System32\CustomShellHost.exe
 Detection:
   - IOC: CustomShellHost.exe is unlikely to run on normal workstations
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff5102832031425f6eed011dd3a2e62653008c94/rules/windows/process_creation/proc_creation_win_lolbin_customshellhost.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2084b14121-9d14-416e-800b-f3b829c5a14d
 Resources:
   - Link: https://twitter.com/YoSignals/status/1381353520088113154
   - Link: https://docs.microsoft.com/en-us/windows/configuration/kiosk-shelllauncher

--- a/yml/OSBinaries/DataSvcUtil.yml
+++ b/yml/OSBinaries/DataSvcUtil.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.github.com/teixeira0xfffff/837e5bfed0d1b0a29a7cb1e5dbdd9ca6
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/dc030e0128a38510b0a866e1210f5ebd7c418c0b/rules/windows/process_creation/process_creation_lolbas_data_exfiltration_by_using_datasvcutil.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e290b10b-1023-4452-a4a9-eb31a9013b3a
   - IOC: The DataSvcUtil.exe tool is installed in the .NET Framework directory.
   - IOC: Preventing/Detecting DataSvcUtil with non-RFC1918 addresses by Network IPS/IDS.
   - IOC: Monitor process creation for non-SYSTEM and non-LOCAL SERVICE accounts launching DataSvcUtil.

--- a/yml/OSBinaries/Desktopimgdownldr.yml
+++ b/yml/OSBinaries/Desktopimgdownldr.yml
@@ -16,8 +16,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_desktopimgdownldr.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/win_susp_desktopimgdownldr_file.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20bb58aa4a-b80b-415a-a2c0-2f65a4c81009
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fc4f4817-0c53-4683-a4ee-b17a64bc1039
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
   - IOC: desktopimgdownldr.exe that creates non-image file
   - IOC: Change of HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\PersonalizationCSP\LockScreenImageUrl

--- a/yml/OSBinaries/DeviceCredentialDeployment.yml
+++ b/yml/OSBinaries/DeviceCredentialDeployment.yml
@@ -15,7 +15,7 @@ Full_Path:
   - Path: C:\Windows\System32\DeviceCredentialDeployment.exe
 Detection:
   - IOC: DeviceCredentialDeployment.exe should not be run on a normal workstation
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff5102832031425f6eed011dd3a2e62653008c94/rules/windows/process_creation/proc_creation_win_lolbin_device_credential_deployment.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b8b1b304-a60f-4999-9a6e-c547bde03ffd
 Acknowledgement:
   - Person: Elliot Killick
     Handle: '@elliotkillick'

--- a/yml/OSBinaries/Dfsvc.yml
+++ b/yml/OSBinaries/Dfsvc.yml
@@ -19,7 +19,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
 Resources:
   - Link: https://github.com/api0cradle/ShmooCon-2015/blob/master/ShmooCon-2015-Simple-WLEvasion.pdf
   - Link: https://stackoverflow.com/questions/13312273/clickonce-runtime-dfsvc-exe

--- a/yml/OSBinaries/Diantz.yml
+++ b/yml/OSBinaries/Diantz.yml
@@ -24,8 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0593446f96c57a8b64e2b5b9fd15a20f1c56acab/rules/windows/process_creation/win_pc_lolbas_diantz_ads.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0f33cbc85bf4b23b8d8308bfcc8b21a9e5431ee7/rules/windows/process_creation/win_pc_lolbas_diantz_remote_cab.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%206b369ced-4b1d-48f1-b427-fdc0de0790bd
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20185d7418-f250-42d0-b72e-0c8b70661e93
   - IOC: diantz storing data into alternate data streams.
   - IOC: diantz getting a file from a remote machine or the internet.
 Resources:

--- a/yml/OSBinaries/Diskshadow.yml
+++ b/yml/OSBinaries/Diskshadow.yml
@@ -24,8 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b4d5b44ea86cda24f38a87d3b0c5f9d4455bf841/rules/windows/process_creation/win_susp_diskshadow.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b3df5bf325461df9bcfeb051895b0c8dc3258234/rules/windows/process_creation/win_shadow_copies_deletion.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200c2f8629-7129-4a8a-9897-7e0768f13ff2
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c947b146-0abc-4c87-9c64-b17e9d7274a2
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
   - IOC: Child process from diskshadow.exe
 Resources:

--- a/yml/OSBinaries/Dnscmd.yml
+++ b/yml/OSBinaries/Dnscmd.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b08b3e2b0d5111c637dbede1381b07cb79f8c2eb/rules/windows/process_creation/process_creation_dns_serverlevelplugindll.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20f63b56ee-3f79-4b8a-97fb-5c48007e8573
   - IOC: Dnscmd.exe loading dll from UNC/arbitrary path
 Resources:
   - Link: https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83

--- a/yml/OSBinaries/Esentutl.yml
+++ b/yml/OSBinaries/Esentutl.yml
@@ -53,10 +53,10 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/fb750721b25ec4573acc32a0822d047a8ecdf269/rules/windows/deprecated/win_susp_vssadmin_ntds_activity.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/fb750721b25ec4573acc32a0822d047a8ecdf269/rules/windows/deprecated/win_susp_esentutl_activity.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/bacb44ab972343358bae612e4625f8ba2e043573/rules/windows/process_creation/process_susp_esentutl_params.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_copying_sensitive_files_with_credential_data.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b932b60f-fdda-4d53-8eda-a170c1d97bbd
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2056a8189f-11b2-48c8-8ca7-c54b03c2fbf7
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207df1713a-1a5b-4a4b-a071-dc83b144a101
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e7be6119-fc37-43f0-ad4f-1f3f99be2f9f
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/esentutl_sam_copy.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/f6421d8c534f295518a2c945f530e8afc4c8ad1b/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
 Resources:

--- a/yml/OSBinaries/Eventvwr.yml
+++ b/yml/OSBinaries/Eventvwr.yml
@@ -24,9 +24,9 @@ Full_Path:
 Code_Sample:
   - Code: https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-EventVwrBypass.ps1
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b08b3e2b0d5111c637dbede1381b07cb79f8c2eb/rules/windows/process_creation/process_creation_sysmon_uac_bypass_eventvwr.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b08b3e2b0d5111c637dbede1381b07cb79f8c2eb/rules/windows/registry_event/registry_event_uac_bypass_eventvwr.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/197615345b927682ab7ad7fa3c5f5bb2ed911eed/rules/windows/file/file_event/file_event_win_uac_bypass_eventvwr.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20be344333-921d-4c4d-8bb8-e584cf584780
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207c81fec3-1c1d-43b0-996a-46753041b1b6
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2063e4f530-65dc-49cc-8f80-ccfa95c69d43
   - Elastic: https://github.com/elastic/detection-rules/blob/d31ea6253ea40789b1fc49ade79b7ec92154d12a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/eventvwr_uac_bypass.yml
   - IOC: eventvwr.exe launching child process other than mmc.exe

--- a/yml/OSBinaries/Expand.yml
+++ b/yml/OSBinaries/Expand.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b25fbbea54014565fc4551f94c97c0d7550b1c04/rules/windows/process_creation/sysmon_expand_cabinet_files.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209f107a84-532c-41af-b005-8d12a607639f
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
 Resources:
   - Link: https://twitter.com/infosecn1nja/status/986628482858807297

--- a/yml/OSBinaries/Explorer.yml
+++ b/yml/OSBinaries/Explorer.yml
@@ -22,8 +22,8 @@ Full_Path:
   - Path: C:\Windows\explorer.exe
   - Path: C:\Windows\SysWOW64\explorer.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_explorer_break_proctree.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_explorer.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20949f1ffb-6e85-4f00-ae1e-c3c5b190d605
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209eb271b9-24ae-4cd4-9465-19cfc1047f3e
   - Elastic: https://github.com/elastic/detection-rules/blob/f2bc0c685d83db7db395fc3dc4b9729759cd4329/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
   - IOC: Multiple instances of explorer.exe or explorer.exe using the /root command line is suspicious.
 Resources:

--- a/yml/OSBinaries/Extexport.yml
+++ b/yml/OSBinaries/Extexport.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0f33cbc85bf4b23b8d8308bfcc8b21a9e5431ee7/rules/windows/process_creation/win_pc_lolbas_extexport.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fb0b815b-f5f6-4f50-970f-ffe21f253f7a
   - IOC: Extexport.exe loads dll and is execute from other folder the original path
 Resources:
   - Link: http://www.hexacorn.com/blog/2018/04/24/extexport-yet-another-lolbin/

--- a/yml/OSBinaries/Extrac32.yml
+++ b/yml/OSBinaries/Extrac32.yml
@@ -39,8 +39,8 @@ Code_Sample:
   - Code:
 Detection:
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0f33cbc85bf4b23b8d8308bfcc8b21a9e5431ee7/rules/windows/process_creation/win_pc_lolbas_extrac32.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0f33cbc85bf4b23b8d8308bfcc8b21a9e5431ee7/rules/windows/process_creation/win_pc_lolbas_extrac32_ads.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20aa8e035d-7be4-48d3-a944-102aec04400d
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204b13db67-0c45-40f1-aba8-66a1a7198a1e
 Resources:
   - Link: https://oddvar.moe/2018/04/11/putting-data-in-alternate-data-streams-and-how-to-execute-it-part-2/
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Findstr.yml
+++ b/yml/OSBinaries/Findstr.yml
@@ -38,7 +38,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_findstr.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20bf6c39fc-e203-45b9-9538-05397c1b4f3f
 Resources:
   - Link: https://oddvar.moe/2018/04/11/putting-data-in-alternate-data-streams-and-how-to-execute-it-part-2/
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Finger.yml
+++ b/yml/OSBinaries/Finger.yml
@@ -15,7 +15,7 @@ Full_Path:
   - Path: c:\windows\system32\finger.exe
   - Path: c:\windows\syswow64\finger.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_finger_usage.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20af491bca-e752-4b44-9c86-df5680533dbc
   - IOC: finger.exe should not be run on a normal workstation.
   - IOC: finger.exe connecting to external resources.
 Resources:

--- a/yml/OSBinaries/FltMC.yml
+++ b/yml/OSBinaries/FltMC.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\fltMC.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/c27084dd0c432335fa4369e5002a61dfe0ab9c65/rules/windows/process_creation/win_sysmon_driver_unload.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204d7cda18-1b12-4e52-b45c-d28653210df8
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_via_filter_manager.toml
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/unload_sysmon_filter_driver.yml
   - IOC: 4688 events with fltMC.exe

--- a/yml/OSBinaries/Forfiles.yml
+++ b/yml/OSBinaries/Forfiles.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_indirect_cmd.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fa47597e-90e9-41cd-ab72-c3b74cfb0d02
 Resources:
   - Link: https://twitter.com/vector_sec/status/896049052642533376
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Ftp.yml
+++ b/yml/OSBinaries/Ftp.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_ftp.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2006b401f4-107c-4ff9-947f-9ec1e7649f1e
   - IOC: cmd /c as child process of ftp.exe
 Resources:
   - Link: https://twitter.com/0xAmit/status/1070063130636640256

--- a/yml/OSBinaries/Gpscript.yml
+++ b/yml/OSBinaries/Gpscript.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/35a7244c62820fbc5a832e50b1e224ac3a1935da/rules/windows/process_creation/proc_creation_win_lolbin_gpscript.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%201e59c230-6670-45bf-83b0-98903780607e
   - IOC: Scripts added in local group policy
   - IOC: Execution of Gpscript.exe after logon
 Resources:

--- a/yml/OSBinaries/Hh.yml
+++ b/yml/OSBinaries/Hh.yml
@@ -24,8 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_hh_chm.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_html_help_spawn.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2068c8acb4-1b60-4890-8e82-3ddf7a6dba84
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2052cad028-0ff0-4854-8f67-d25dfcbc78b4
   - Elastic: https://github.com/elastic/detection-rules/blob/ef7548f04c4341e0d1a172810330d59453f46a21/rules/windows/execution_via_compiled_html_file.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/detect_html_help_spawn_child_process.yml

--- a/yml/OSBinaries/IMEWDBLD.yml
+++ b/yml/OSBinaries/IMEWDBLD.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\IME\SHARED\IMEWDBLD.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/bea6f18d350d9c9fdc067f93dde0e9b11cc22dc2/rules/windows/network_connection/net_connection_win_imewdbld.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%208d7e392e-9b28-49e1-831d-5949c6281228
 Resources:
   - Link: https://twitter.com/notwhickey/status/1367493406835040265
 Acknowledgement:

--- a/yml/OSBinaries/Ie4uinit.yml
+++ b/yml/OSBinaries/Ie4uinit.yml
@@ -21,7 +21,7 @@ Code_Sample:
 Detection:
   - IOC: ie4uinit.exe copied outside of %windir%
   - IOC: ie4uinit.exe loading an inf file (ieuinit.inf) from outside %windir%
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/bea6f18d350d9c9fdc067f93dde0e9b11cc22dc2/rules/windows/process_creation/proc_creation_win_lolbin_ie4uinit.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d3bf399f-b0cf-4250-8bb4-dfc192ab81dc
 Resources:
   - Link: https://bohops.com/2018/03/10/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence-part-2/
 Acknowledgement:

--- a/yml/OSBinaries/Ieexec.yml
+++ b/yml/OSBinaries/Ieexec.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2082a19e3a-2bfe-4a91-8c0d-5d4c98fbb719
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml

--- a/yml/OSBinaries/Ilasm.yml
+++ b/yml/OSBinaries/Ilasm.yml
@@ -25,7 +25,7 @@ Code_Sample:
   - Code:
 Detection:
   - IOC: Ilasm may not be used often in production environments (such as on endpoints)
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/bea6f18d350d9c9fdc067f93dde0e9b11cc22dc2/rules/windows/process_creation/proc_creation_win_lolbin_ilasm.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20850d55f9-6eeb-4492-ad69-a72338f65ba4
 Resources:
   - Link: https://github.com/LuxNoBulIshit/BeforeCompileBy-ilasm/blob/master/hello_world.txt
 Acknowledgement:

--- a/yml/OSBinaries/Infdefaultinstall.yml
+++ b/yml/OSBinaries/Infdefaultinstall.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.github.com/KyleHanslovan/5e0f00d331984c1fb5be32c40f3b265a
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/85d47aeabc25bbd023284849f4466c1e00b855ce/rules/windows/process_creation/process_creation_infdefaultinstall.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20ce7cf472-6fcc-490a-9481-3786840b5d9b
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://twitter.com/KyleHanslovan/status/911997635455852544

--- a/yml/OSBinaries/Installutil.yml
+++ b/yml/OSBinaries/Installutil.yml
@@ -31,7 +31,7 @@ Full_Path:
   - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe
   - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\InstallUtil.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2082a19e3a-2bfe-4a91-8c0d-5d4c98fbb719
   - Elastic: https://github.com/elastic/detection-rules/blob/cc241c0b5ec590d76cb88ec638d3cc37f68b5d50/rules/windows/defense_evasion_installutil_beacon.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
 Resources:

--- a/yml/OSBinaries/Jsc.yml
+++ b/yml/OSBinaries/Jsc.yml
@@ -26,7 +26,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/35a7244c62820fbc5a832e50b1e224ac3a1935da/rules/windows/process_creation/proc_creation_win_lolbin_jsc.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2052788a70-f1da-40dd-8fbd-73b5865d6568
   - IOC: Jsc.exe should normally not run a system unless it is used for development.
 Resources:
   - Link: https://twitter.com/DissectMalware/status/998797808907046913

--- a/yml/OSBinaries/Makecab.yml
+++ b/yml/OSBinaries/Makecab.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/688df3405afd778d63a2ea36a084344a2052848c/rules/windows/process_creation/process_creation_alternate_data_streams.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207f43c430-5001-4f8b-aaa9-c3b88f18fa5c
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
   - IOC: Makecab retrieving files from Internet
   - IOC: Makecab storing data into alternate data streams

--- a/yml/OSBinaries/Mavinject.yml
+++ b/yml/OSBinaries/Mavinject.yml
@@ -24,8 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_mavinject_proc_inj.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/c44b22b52fce406d45ddb6743a02b9ff8c62c7c6/rules/windows/process_creation/sysmon_creation_mavinject_dll.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2017eb8e57-9983-420d-ad8a-2c4976c22eb8
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204f73421b-5a0b-4bbf-a892-5a7fb99bea66
   - IOC: mavinject.exe should not run unless APP-v is in use on the workstation
 Resources:
   - Link: https://twitter.com/gN3mes1s/status/941315826107510784

--- a/yml/OSBinaries/Microsoft.Workflow.Compiler.yml
+++ b/yml/OSBinaries/Microsoft.Workflow.Compiler.yml
@@ -30,7 +30,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/85d47aeabc25bbd023284849f4466c1e00b855ce/rules/windows/process_creation/win_workflow_compiler.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20419dbf2b-8a9b-4bea-bf99-7544b050ec8d
   - Splunk: https://github.com/splunk/security_content/blob/961a81d4a5cb5c5febec4894d6d812497171a85c/detections/endpoint/suspicious_microsoft_workflow_compiler_usage.yml
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/suspicious_microsoft_workflow_compiler_rename.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml

--- a/yml/OSBinaries/Mmc.yml
+++ b/yml/OSBinaries/Mmc.yml
@@ -24,8 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_mmc_spawn_shell.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b731c2059445eef53e37232a5f3634c3473aae0c/rules/windows/file_event/sysmon_uac_bypass_dotnet_profiler.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2005a2ab7e-ce11-4b63-86db-ab32e763e11d
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2093a19907-d4f9-4deb-9f91-aac4692776a6
 Resources:
   - Link: https://bohops.com/2018/08/18/abusing-the-com-registry-structure-part-2-loading-techniques-for-evasion-and-persistence/
   - Link: https://offsec.almond.consulting/UAC-bypass-dotnet.html

--- a/yml/OSBinaries/MpCmdRun.yml
+++ b/yml/OSBinaries/MpCmdRun.yml
@@ -32,7 +32,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/159bf4bbc103cc2be3fef4b7c2e7c8b23b63fd10/rules/windows/process_creation/win_susp_mpcmdrun_download.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2046123129-1024-423e-9fae-43af4a0fa9a5
   - Elastic: https://github.com/elastic/detection-rules/blob/6ef5c53b0c15e344f0f2d1649941391aea6fa253/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
   - IOC: MpCmdRun storing data into alternate data streams.
   - IOC: MpCmdRun retrieving a file from a remote machine or the internet that is not expected.

--- a/yml/OSBinaries/Msbuild.yml
+++ b/yml/OSBinaries/Msbuild.yml
@@ -50,8 +50,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/5a3af872d86903c13e508348f54e3b519eb01dce/rules/windows/network_connection/silenttrinity_stager_msbuild_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2082a19e3a-2bfe-4a91-8c0d-5d4c98fbb719
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2050e54b8d-ad73-43f8-96a1-5191685b17a4
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/suspicious_msbuild_spawn.yml
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/suspicious_msbuild_rename.yml
   - Splunk: https://github.com/splunk/security_content/blob/a1afa0fa605639cbef7d528dec46ce7c8112194a/detections/endpoint/msbuild_suspicious_spawned_by_script_process.yml

--- a/yml/OSBinaries/Msconfig.yml
+++ b/yml/OSBinaries/Msconfig.yml
@@ -16,8 +16,8 @@ Full_Path:
 Code_Sample:
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/mscfgtlc.xml
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b731c2059445eef53e37232a5f3634c3473aae0c/rules/windows/process_creation/win_uac_bypass_msconfig_gui.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b731c2059445eef53e37232a5f3634c3473aae0c/rules/windows/file_event/sysmon_uac_bypass_msconfig_gui.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20ad92e3f9-7eb6-460e-96b1-582b0ccbb980
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2041bb431f-56d8-4691-bb56-ed34e390906f
   - IOC: mscfgtlc.xml changes in system32 folder
 Resources:
   - Link: https://twitter.com/pabraeken/status/991314564896690177

--- a/yml/OSBinaries/Msdt.yml
+++ b/yml/OSBinaries/Msdt.yml
@@ -31,8 +31,8 @@ Full_Path:
 Code_Sample:
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSBinaries/Payload/PCW8E57.xml
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6199a703221a98ae6ad343c79c558da375203e4e/rules/windows/process_creation/proc_creation_win_lolbin_msdt_answer_file.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6199a703221a98ae6ad343c79c558da375203e4e/rules/windows/process_creation/proc_creation_win_msdt.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209c8c7000-3065-44a8-a555-79bcba5d9955
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20258fc8ce-8352-443a-9120-8a11e4857fa5
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
 Resources:
   - Link: https://web.archive.org/web/20160322142537/https://cybersyndicates.com/2015/10/a-no-bull-guide-to-malicious-windows-trouble-shooting-packs-and-application-whitelist-bypass/

--- a/yml/OSBinaries/Mshta.yml
+++ b/yml/OSBinaries/Mshta.yml
@@ -45,13 +45,13 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.github.com/bohops/6ded40c4989c673f2e30b9a6c1985019
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/05c58b4892942c34bfa01e9ada88ef2663858e1c/rules/windows/process_creation/win_susp_mshta_pattern.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_invoke_obfuscation_via_use_mhsta.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_lethalhta.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/f4ac416ef44862930730f8b7f16362b0e987bc71/rules/windows/process_creation/win_shell_spawn_mshta.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_mshta_javascript.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e32f92d1-523e-49c3-9374-bdb13b46a3ba
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20ac20ae82-8758-4f38-958e-b44a3140ca88
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20ed5d72a6-f8f4-479d-ba79-02f6a80d7471
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20772bb24c-8df2-4be0-9157-ae4dfa794037
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2067f113fa-e23d-4271-befa-30113b3e08b1
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e4b63079-6198-405c-abd7-3fe8b0ce3263
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204508a70e-97ef-4300-b62b-ff27992990ea
   - Elastic: https://github.com/elastic/detection-rules/blob/f8f643041a584621e66cf8e6d534ad3db92edc29/rules/windows/defense_evasion_mshta_beacon.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/cc241c0b5ec590d76cb88ec638d3cc37f68b5d50/rules/windows/lateral_movement_dcom_hta.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml

--- a/yml/OSBinaries/Msiexec.yml
+++ b/yml/OSBinaries/Msiexec.yml
@@ -38,8 +38,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_msiexec_web_install.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_msiexec_cwd.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20f7b5f842-a6af-4da5-9e95-e32478f3cd2f
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e22a6eb2-f8a5-44b5-8b44-a2dbd47b1144
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/uninstall_app_using_msiexec.yml
   - IOC: msiexec.exe retrieving files from Internet

--- a/yml/OSBinaries/Netsh.yml
+++ b/yml/OSBinaries/Netsh.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0a410010a2655bc6f2aae73b9fb3b2c00ed589f7/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2056321594-9087-49d9-bf10-524fe8479452
   - Splunk: https://github.com/splunk/security_content/blob/2b87b26bdc2a84b65b1355ffbd5174bdbdb1879c/detections/endpoint/processes_launching_netsh.yml
   - Splunk: https://github.com/splunk/security_content/blob/08ed88bd88259c03c771c30170d2934ed0a8f878/detections/deprecated/processes_created_by_netsh.yml
   - IOC: Netsh initiating a network connection

--- a/yml/OSBinaries/Odbcconf.yml
+++ b/yml/OSBinaries/Odbcconf.yml
@@ -33,7 +33,7 @@ Full_Path:
 Code_Sample:
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/58b5eb751379501aa237275f14381f0902e979a5/Archive-Old-Version/OSBinaries/Payload/file.rsp
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_odbcconf.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2065d2be45-8600-4042-b4c0-577a1ff8a60e
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
 Resources:

--- a/yml/OSBinaries/OfflineScannerShell.yml
+++ b/yml/OSBinaries/OfflineScannerShell.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Program Files\Windows Defender\Offline\OfflineScannerShell.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/bea6f18d350d9c9fdc067f93dde0e9b11cc22dc2/rules/windows/process_creation/proc_creation_win_lolbas_offlinescannershell.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2002b18447-ea83-4b1b-8805-714a8a34546a
   - IOC: OfflineScannerShell.exe should not be run on a normal workstation
 Acknowledgement:
   - Person: Elliot Killick

--- a/yml/OSBinaries/OneDriveStandaloneUpdater.yml
+++ b/yml/OSBinaries/OneDriveStandaloneUpdater.yml
@@ -16,7 +16,7 @@ Full_Path:
 Detection:
   - IOC: HKCU\Software\Microsoft\OneDrive\UpdateOfficeConfig\UpdateRingSettingURLFromOC being set to a suspicious non-Microsoft controlled URL
   - IOC: Reports of downloading from suspicious URLs in %localappdata%\OneDrive\setup\logs\StandaloneUpdate_*.log files
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff5102832031425f6eed011dd3a2e62653008c94/rules/windows/registry/registry_set/registry_set_lolbin_onedrivestandaloneupdater.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%203aff0be0-7802-4a7e-a4fa-c60c74bc5e1d
 Resources:
   - Link: https://github.com/LOLBAS-Project/LOLBAS/pull/153
 Acknowledgement:

--- a/yml/OSBinaries/Pcalua.yml
+++ b/yml/OSBinaries/Pcalua.yml
@@ -30,7 +30,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_indirect_cmd.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fa47597e-90e9-41cd-ab72-c3b74cfb0d02
 Resources:
   - Link: https://twitter.com/KyleHanslovan/status/912659279806640128
 Acknowledgement:

--- a/yml/OSBinaries/Pcwrun.yml
+++ b/yml/OSBinaries/Pcwrun.yml
@@ -21,7 +21,7 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\pcwrun.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6199a703221a98ae6ad343c79c558da375203e4e/rules/windows/process_creation/proc_creation_win_lolbin_pcwrun_follina.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%206004abd0-afa4-4557-ba90-49d172e0a299
 Resources:
   - Link: https://twitter.com/pabraeken/status/991335019833708544
   - Link: https://twitter.com/nas_bench/status/1535663791362519040

--- a/yml/OSBinaries/Pktmon.yml
+++ b/yml/OSBinaries/Pktmon.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/35a7244c62820fbc5a832e50b1e224ac3a1935da/rules/windows/process_creation/proc_creation_win_lolbin_pktmon.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20f956c7c1-0f60-4bc5-b7d7-b39ab3c08908
   - IOC: .etl files found on system
 Resources:
   - Link: https://binar-x79.com/windows-10-secret-sniffer/

--- a/yml/OSBinaries/Pnputil.yml
+++ b/yml/OSBinaries/Pnputil.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code: https://github.com/LuxNoBulIshit/test.inf/blob/main/inf
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/a8a0d546f347febb0423aa920dbc10713cc1f92f/rules/windows/process_creation/process_creation_lolbins_suspicious_driver_installed_by_pnputil.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20a2ea3ae7-d3d0-40a0-a55c-25a45c87cac1
 Acknowledgement:
   - Person: Hai Vaknin(Lux)
     Handle: '@LuxNoBulIshit'

--- a/yml/OSBinaries/Presentationhost.yml
+++ b/yml/OSBinaries/Presentationhost.yml
@@ -22,7 +22,7 @@ Full_Path:
   - Path: C:\Windows\System32\Presentationhost.exe
   - Path: C:\Windows\SysWOW64\Presentationhost.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/a38c0218765a89f5d18eadd49639c72a5d25d944/rules/windows/process_creation/win_susp_presentationhost_execution.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d149a338-ae47-408e-a8ff-9064220c0b34
   - IOC: Execution of .xbap files may not be common on production workstations
 Resources:
   - Link: https://github.com/api0cradle/ShmooCon-2015/blob/master/ShmooCon-2015-Simple-WLEvasion.pdf

--- a/yml/OSBinaries/Print.yml
+++ b/yml/OSBinaries/Print.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_print.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20bafac3d6-7de9-4dd9-8874-4a1194b493ed
   - IOC: Print.exe retrieving files from internet
   - IOC: Print.exe creating executable files on disk
 Resources:

--- a/yml/OSBinaries/PrintBrm.yml
+++ b/yml/OSBinaries/PrintBrm.yml
@@ -21,7 +21,7 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\spool\tools\PrintBrm.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/35a7244c62820fbc5a832e50b1e224ac3a1935da/rules/windows/process_creation/proc_creation_win_lolbin_printbrm.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20cafeeba3-01da-4ab4-b6c4-a31b1d9730c7
   - IOC: PrintBrm.exe should not be run on a normal workstation
 Resources:
   - Link: https://twitter.com/elliotkillick/status/1404117015447670800

--- a/yml/OSBinaries/Psr.yml
+++ b/yml/OSBinaries/Psr.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/c44b22b52fce406d45ddb6743a02b9ff8c62c7c6/rules/windows/process_creation/win_susp_psr_capture_screenshots.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%202158f96f-43c2-43cb-952a-ab4580f32382
   - IOC: psr.exe spawned
   - IOC: suspicious activity when running with "/gui 0" flag
 Resources:

--- a/yml/OSBinaries/Rasautou.yml
+++ b/yml/OSBinaries/Rasautou.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_rasautou_dll_execution.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20cd3d1298-eb3b-476c-ac67-12847de55813
   - IOC: rasautou.exe command line containing -d and -p
 Resources:
   - Link: https://github.com/fireeye/DueDLLigence

--- a/yml/OSBinaries/Rdrleakdiag.yml
+++ b/yml/OSBinaries/Rdrleakdiag.yml
@@ -31,8 +31,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/197615345b927682ab7ad7fa3c5f5bb2ed911eed/rules/windows/process_creation/proc_creation_win_proc_dump_rdrleakdiag.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/197615345b927682ab7ad7fa3c5f5bb2ed911eed/rules/windows/process_creation/proc_creation_win_process_dump_rdrleakdiag.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%206355a919-2e97-4285-a673-74645566340d
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20edadb1e5-5919-4e4c-8462-a9e643b02c4b
   - Elastic: https://www.elastic.co/guide/en/security/current/potential-credential-access-via-windows-utilities.html
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
 Resources:

--- a/yml/OSBinaries/Reg.yml
+++ b/yml/OSBinaries/Reg.yml
@@ -24,9 +24,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regedit_import_keys_ads.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regedit_import_keys.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/9f27ab5426a0b061f1f2787e3dc947d6d75ad8c0/rules/windows/process_creation/win_grabbing_sensitive_hives_via_reg.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200b80ade5-6997-4b1d-99a1-71701778ea61
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2073bba97f-a82d-42ce-b315-9182e76c57b1
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fd877b94-9bb5-4191-bb25-d79cbd93c167
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/attempted_credential_dump_from_registry_via_reg_exe.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/f6421d8c534f295518a2c945f530e8afc4c8ad1b/rules/windows/credential_access_dump_registry_hives.toml
   - IOC: reg.exe writing to an ADS

--- a/yml/OSBinaries/Regasm.yml
+++ b/yml/OSBinaries/Regasm.yml
@@ -26,7 +26,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2082a19e3a-2bfe-4a91-8c0d-5d4c98fbb719
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
   - Splunk: https://github.com/splunk/security_content/blob/bc93e670f5dcb24e96fbe3664d6bcad92df5acad/docs/_stories/suspicious_regsvcs_regasm_activity.md
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/detect_regasm_with_network_connection.yml

--- a/yml/OSBinaries/Regedit.yml
+++ b/yml/OSBinaries/Regedit.yml
@@ -23,7 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regedit_import_keys_ads.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200b80ade5-6997-4b1d-99a1-71701778ea61
   - IOC: regedit.exe reading and writing to alternate data stream
   - IOC: regedit.exe should normally not be executed by end-users
 Resources:

--- a/yml/OSBinaries/Regini.yml
+++ b/yml/OSBinaries/Regini.yml
@@ -17,8 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regini_ads.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/d9edc9f0e365257aa497cc7707e58f396088958e/rules/windows/process_creation/win_regini.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2077946e79-97f1-45a2-84b4-f37b5c0d8682
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%205f60740a-f57b-4e76-82a1-15b6ff2cb134
   - IOC: regini.exe reading from ADS
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f

--- a/yml/OSBinaries/Register-cimprovider.yml
+++ b/yml/OSBinaries/Register-cimprovider.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/35a7244c62820fbc5a832e50b1e224ac3a1935da/rules/windows/process_creation/proc_creation_win_susp_register_cimprovider.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20a2910908-e86f-4687-aeba-76a5f996e652
   - IOC: Register-cimprovider.exe execution and cmdline DLL load may be supsicious
 Resources:
   - Link: https://twitter.com/PhilipTsukerman/status/992021361106268161

--- a/yml/OSBinaries/Regsvcs.yml
+++ b/yml/OSBinaries/Regsvcs.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/a04fbe2a99f1dcbbfeb0ee4957ae4b06b0866254/rules/windows/process_creation/win_possible_applocker_bypass.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2082a19e3a-2bfe-4a91-8c0d-5d4c98fbb719
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
   - Splunk: https://github.com/splunk/security_content/blob/bee2a4cefa533f286c546cbe6798a0b5dec3e5ef/detections/endpoint/detect_regsvcs_with_network_connection.yml
 Resources:

--- a/yml/OSBinaries/Regsvr32.yml
+++ b/yml/OSBinaries/Regsvr32.yml
@@ -38,11 +38,11 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6fbce11094285e5ba13fe101b9cb70f5b1ece198/rules/windows/process_creation/win_susp_regsvr32_anomalies.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6d56e400d209daa77a7900d950a7c587dc0cd2e5/rules/windows/network_connection/sysmon_regsvr32_network_activity.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/5951ad1d9a781a49d61df9af03c7b83ac67a0012/rules/windows/dns_query/dns_query_regsvr32_network_activity.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_regsvr32_flags_anomaly.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%208e2b24c9-4add-46a0-b4bb-0057b4e6187d
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c7e91a02-d771-4a6d-a700-42587e0b1095
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2036e037c4-c228-4866-b6a3-48eb292b9955
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b236190c-1c61-41e9-84b3-3fe03f6d76b0
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e4b63079-6198-405c-abd7-3fe8b0ce3263
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_regsvr32_application_control_bypass.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/execution_register_server_program_connecting_to_the_internet.toml

--- a/yml/OSBinaries/Replace.yml
+++ b/yml/OSBinaries/Replace.yml
@@ -25,7 +25,7 @@ Code_Sample:
   - Code:
 Detection:
   - IOC: Replace.exe retrieving files from remote server
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/bea6f18d350d9c9fdc067f93dde0e9b11cc22dc2/rules/windows/process_creation/proc_creation_win_lolbas_replace.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209292293b-8496-4715-9db6-37028dcda4b3
 Resources:
   - Link: https://twitter.com/elceef/status/986334113941655553
   - Link: https://twitter.com/elceef/status/986842299861782529

--- a/yml/OSBinaries/Rpcping.yml
+++ b/yml/OSBinaries/Rpcping.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rpcping.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2093671f99-04eb-4ab4-a161-70d446a84003
 Resources:
   - Link: https://github.com/vysec/RedTips
   - Link: https://twitter.com/vysecurity/status/974806438316072960

--- a/yml/OSBinaries/Rundll32.yml
+++ b/yml/OSBinaries/Rundll32.yml
@@ -66,8 +66,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/network_connection/sysmon_rundll32_net_connections.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20cdc8da7d-c303-42f8-b08c-b4ab47230263
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/defense_evasion_unusual_network_connection_via_rundll32.toml
   - IOC: Outbount Internet/network connections made from rundll32
   - IOC: Suspicious use of cmdline flags such as -sta

--- a/yml/OSBinaries/Runexehelper.yml
+++ b/yml/OSBinaries/Runexehelper.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: c:\windows\system32\runexehelper.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/197615345b927682ab7ad7fa3c5f5bb2ed911eed/rules/windows/process_creation/proc_creation_win_lolbin_runexehelper.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20cd71385d-fd9b-4691-9b98-2b1f7e508714
   - IOC: c:\windows\system32\runexehelper.exe is run
   - IOC: Existence of runexewithargs_output.txt file
 Resources:

--- a/yml/OSBinaries/Runonce.yml
+++ b/yml/OSBinaries/Runonce.yml
@@ -17,8 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6d2acb166070541925636d1d1273e46020e38387/rules/windows/registry_event/sysmon_runonce_persistence.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_runonce_execution.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c74d7efc-8826-45d9-b8bb-f04fac9e4eff
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20198effb6-6c98-4d0c-9ea3-451fa143c45c
   - Elastic: https://github.com/elastic/detection-rules/blob/2926e98c5d998706ef7e248a63fb0367c841f685/rules/windows/persistence_run_key_and_startup_broad.toml
   - IOC: Registy key add - HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components\YOURKEY
 Resources:

--- a/yml/OSBinaries/Runscripthelper.yml
+++ b/yml/OSBinaries/Runscripthelper.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_runscripthelper.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20eca49c87-8a75-4f13-9c73-a5a29e845f03
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: Event 4014 - Powershell logging
   - IOC: Event 400

--- a/yml/OSBinaries/Sc.yml
+++ b/yml/OSBinaries/Sc.yml
@@ -24,9 +24,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_new_service_creation.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_using_sc_to_change_sevice_image_path_by_non_admin.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_susp_service_path_modification.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207fe71fc9-de3b-432a-8d57-8c809efc10ab
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d937b75f-a665-4480-88a5-2f20e9f9b22a
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20138d3531-8793-4f50-a2cd-f291b2863d78
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/sc_exe_manipulating_windows_services.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/lateral_movement_cmd_service.toml
   - IOC: Unexpected service creation

--- a/yml/OSBinaries/Schtasks.yml
+++ b/yml/OSBinaries/Schtasks.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/59000b993d6280d9bf063eefdcdf30ea0e83aa5e/rules/windows/process_creation/win_susp_schtask_creation.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2092626ddd-662c-49e3-ac59-f6535f12d189
   - Elastic: https://github.com/elastic/detection-rules/blob/ef7548f04c4341e0d1a172810330d59453f46a21/rules/windows/persistence_local_scheduled_task_creation.toml
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/schtasks_scheduling_job_on_remote_system.yml
   - IOC: Suspicious task creation events

--- a/yml/OSBinaries/Scriptrunner.yml
+++ b/yml/OSBinaries/Scriptrunner.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/765acac3742310764495ed5a2006bc0ced5b1a67/rules/windows/process_creation/win_susp_servu_process_pattern.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2058f4ea09-0fc2-4520-ba18-b85c540b0eaf
   - IOC: Scriptrunner.exe should not be in use unless App-v is deployed
 Resources:
   - Link: https://twitter.com/KyleHanslovan/status/914800377580503040

--- a/yml/OSBinaries/Setres.yml
+++ b/yml/OSBinaries/Setres.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: c:\windows\system32\setres.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_setres.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20835e75bf-4bfd-47a4-b8a6-b766cac8bcb7
   - IOC: Unusual location for choice.exe file
   - IOC: Process created from choice.com binary
   - IOC: Existence of choice.cmd file

--- a/yml/OSBinaries/SettingSyncHost.yml
+++ b/yml/OSBinaries/SettingSyncHost.yml
@@ -22,7 +22,7 @@ Full_Path:
   - Path: C:\Windows\System32\SettingSyncHost.exe
   - Path: C:\Windows\SysWOW64\SettingSyncHost.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_using_settingsynchost_as_lolbin.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b2ddd389-f676-4ac4-845a-e00781a48e5f
   - IOC: SettingSyncHost.exe should not be run on a normal workstation
 Resources:
   - Link: https://www.hexacorn.com/blog/2020/02/02/settingsynchost-exe-as-a-lolbin/

--- a/yml/OSBinaries/Ssh.yml
+++ b/yml/OSBinaries/Ssh.yml
@@ -20,7 +20,7 @@ Commands:
 Full_Path:
   - Path: c:\windows\system32\OpenSSH\ssh.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/197615345b927682ab7ad7fa3c5f5bb2ed911eed/rules/windows/process_creation/proc_creation_win_lolbin_ssh.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207d6d30b8-5b91-4b90-a891-46cccaf29598
   - IOC: Event ID 4624 with process name C:\Windows\System32\OpenSSH\sshd.exe.
   - IOC: command line arguments specifying execution.
 Resources:

--- a/yml/OSBinaries/Stordiag.yml
+++ b/yml/OSBinaries/Stordiag.yml
@@ -15,7 +15,7 @@ Full_Path:
   - Path: c:\windows\system32\stordiag.exe
   - Path: c:\windows\syswow64\stordiag.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/8b86a79ef0ca2f32c006c327350b76b47b604690/rules/windows/process_creation/process_creation_stordiag_execution.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20961e0abb-1b1e-4c84-a453-aafe56ad0d34
   - IOC: systeminfo.exe, fltmc.exe or schtasks.exe being executed outside of their normal path of c:\windows\system32\ or c:\windows\syswow64\
 Resources:
   - Link: https://twitter.com/eral4m/status/1451112385041911809

--- a/yml/OSBinaries/Syncappvpublishingserver.yml
+++ b/yml/OSBinaries/Syncappvpublishingserver.yml
@@ -17,8 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/fb750721b25ec4573acc32a0822d047a8ecdf269/rules/windows/deprecated/powershell_syncappvpublishingserver_exe.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/fb750721b25ec4573acc32a0822d047a8ecdf269/rules/windows/deprecated/process_creation_syncappvpublishingserver_exe.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209f7aa113-9da6-4a8d-907c-5f1a4b908299
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fde7929d-8beb-4a4c-b922-be9974671667
   - IOC: SyncAppvPublishingServer.exe should never be in use unless App-V is deployed
 Resources:
   - Link: https://twitter.com/monoxgas/status/895045566090010624

--- a/yml/OSBinaries/Ttdinject.yml
+++ b/yml/OSBinaries/Ttdinject.yml
@@ -24,8 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/7ea6ed3db65e0bd812b051d9bb4fffd27c4c4d0a/rules/windows/create_remote_thread/create_remote_thread_win_ttdinjec.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/7ea6ed3db65e0bd812b051d9bb4fffd27c4c4d0a/rules/windows/process_creation/proc_creation_win_lolbin_ttdinject.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c15e99a3-c474-48ab-b9a7-84549a7a9d16
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b27077d6-23e6-45d2-81a0-e2b356eea5fd
   - IOC: Parent child relationship. Ttdinject.exe parent for executed command
   - IOC: Multiple queries made to the IFEO registry key of an untrusted executable (Ex. "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\payload.exe") from the ttdinject.exe process
 Resources:

--- a/yml/OSBinaries/Tttracer.yml
+++ b/yml/OSBinaries/Tttracer.yml
@@ -24,8 +24,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/5951ad1d9a781a49d61df9af03c7b83ac67a0012/rules/windows/image_load/process_creation_tttracer_mod_load.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/5951ad1d9a781a49d61df9af03c7b83ac67a0012/rules/windows/image_load/sysmon_tttracer_mod_load.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200b4ae027-2a2d-4b93-8c7e-962caaba5b2a
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e76c8240-d68f-4773-8880-5c6f63595aaf
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
   - IOC: Parent child relationship. Tttracer parent for executed command
 Resources:

--- a/yml/OSBinaries/Unregmp2.yml
+++ b/yml/OSBinaries/Unregmp2.yml
@@ -15,7 +15,7 @@ Full_Path:
   - Path: C:\Windows\System32\unregmp2.exe
   - Path: C:\Windows\SysWOW64\unregmp2.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/197615345b927682ab7ad7fa3c5f5bb2ed911eed/rules/windows/process_creation/proc_creation_win_lolbin_unregmp2.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20727454c0-d851-48b0-8b89-385611ab0704
   - IOC: Low-prevalence binaries, with filename 'wmpnscfg.exe', spawned as child-processes of `unregmp2.exe /HideWMP`
 Resources:
   - Link: https://twitter.com/notwhickey/status/1466588365336293385

--- a/yml/OSBinaries/Vbc.yml
+++ b/yml/OSBinaries/Vbc.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_visual_basic_compiler.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207b10f171-7f04-47c7-9fa2-5be43c76e535
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
 Acknowledgement:
   - Person: Lior Adar

--- a/yml/OSBinaries/Verclsid.yml
+++ b/yml/OSBinaries/Verclsid.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_verclsid_runs_com.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d06be4b9-8045-428b-a567-740a26d9db25
   - Splunk: https://github.com/splunk/security_content/blob/a1afa0fa605639cbef7d528dec46ce7c8112194a/detections/endpoint/verclsid_clsid_execution.yml
 Resources:
   - Link: https://gist.github.com/NickTyrer/0598b60112eaafe6d07789f7964290d5

--- a/yml/OSBinaries/Wab.yml
+++ b/yml/OSBinaries/Wab.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/a80c29a7c2e2e500a1a532db2a2a8bd69bd4a63d/rules/windows/registry_event/sysmon_wab_dllpath_reg_change.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fc014922-5def-4da9-a0fc-28c973f41bfb
   - IOC: WAB.exe should normally never be used
 Resources:
   - Link: https://twitter.com/Hexacorn/status/991447379864932352

--- a/yml/OSBinaries/Winget.yml
+++ b/yml/OSBinaries/Winget.yml
@@ -19,7 +19,7 @@ Detection:
   - IOC: winget.exe spawned with local manifest file
   - IOC: Sysmon Event ID 1 - Process Creation
   - Analysis: https://saulpanders.github.io/2022/01/02/New-Year-New-LOLBAS.html
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/8bb3379b6807610d61d29db1d76f5af4840b8208/rules/windows/process_creation/proc_creation_win_lolbin_execution_via_winget.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20313d6012-51a0-4d93-8dfc-de8553239e25
 Resources:
   - Link: https://saulpanders.github.io/2022/01/02/New-Year-New-LOLBAS.html
   - Link: https://docs.microsoft.com/en-us/windows/package-manager/winget/#production-recommended

--- a/yml/OSBinaries/Wlrmdr.yml
+++ b/yml/OSBinaries/Wlrmdr.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/35a7244c62820fbc5a832e50b1e224ac3a1935da/rules/windows/process_creation/proc_creation_win_lolbin_wlrmdr.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209cfc00b6-bfb7-49ce-9781-ef78503154bb
   - IOC: wlrmdr.exe spawning any new processes
 Resources:
   - Link: https://twitter.com/0gtweet/status/1493963591745220608

--- a/yml/OSBinaries/Wmic.yml
+++ b/yml/OSBinaries/Wmic.yml
@@ -45,10 +45,10 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/8beb70e970b814d0ab60625206ea0d8a21a9bff8/rules/windows/image_load/sysmon_wmic_remote_xsl_scripting_dlls.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_xsl_script_processing.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_bypass_squiblytwo.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/c90e31275d2f98b21e55df8a46d0678cfca458d6/rules/windows/process_creation/win_susp_wmic_eventconsumer_create.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2006ce37c2-61ab-4f05-9ff5-b1a96d18ae32
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2005c36dd6-79d6-4a9a-97da-3db20298ab2d
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%208d63dadf-b91b-4187-87b6-34a1114577ea
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20ebef4391-1a81-4761-a40a-1db446c0e625
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_suspicious_wmi_script.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml

--- a/yml/OSBinaries/WorkFolders.yml
+++ b/yml/OSBinaries/WorkFolders.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\WorkFolders.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b4d5b44ea86cda24f38a87d3b0c5f9d4455bf841/rules/windows/process_creation/win_susp_workfolders.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200bbc6369-43e3-453d-9944-cae58821c173
   - IOC: WorkFolders.exe should not be run on a normal workstation
 Resources:
   - Link: https://www.ctus.io/2021/04/12/exploading/

--- a/yml/OSBinaries/Wscript.yml
+++ b/yml/OSBinaries/Wscript.yml
@@ -24,9 +24,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_script_execution.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/file_event/sysmon_susp_clr_logs.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/image_load/sysmon_susp_script_dotnet_clr_dll_load.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%201e33157c-53b1-41ad-bbcc-780b80b58288
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e4b63079-6198-405c-abd7-3fe8b0ce3263
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204508a70e-97ef-4300-b62b-ff27992990ea
   - Elastic: https://github.com/elastic/detection-rules/blob/61afb1c1c0c3f50637b1bb194f3e6fb09f476e50/rules/windows/defense_evasion_unusual_dir_ads.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/cc241c0b5ec590d76cb88ec638d3cc37f68b5d50/rules/windows/command_and_control_remote_file_copy_scripts.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml

--- a/yml/OSBinaries/Wsreset.yml
+++ b/yml/OSBinaries/Wsreset.yml
@@ -16,10 +16,10 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_wsreset_uac_bypass.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/af599e487728ec95eab96d8a980718aa6a0699e4/rules/windows/process_creation/win_uac_bypass_wsreset.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_uac_wsreset.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/registry_event/sysmon_bypass_via_wsreset.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20bdc8918e-a1d5-49d1-9db7-ea0fd91aa2ae
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2089a9a0e0-f61a-42e5-8957-b1479565a658
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d797268e-28a9-49a7-b9a8-2f5039011c5c
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%206ea3bf32-9680-422d-9f50-e90716b12a66
   - Splunk: https://github.com/splunk/security_content/blob/18f63553a9dc1a34122fa123deae2b2f9b9ea391/detections/endpoint/wsreset_uac_bypass.yml
   - IOC: wsreset.exe launching child process other than mmc.exe
   - IOC: Creation or modification of the registry value HKCU\Software\Classes\AppX82a6gwre4fdg3bt635tn5ctqjf8msdd2\Shell\open\command

--- a/yml/OSBinaries/Wuauclt.yml
+++ b/yml/OSBinaries/Wuauclt.yml
@@ -16,9 +16,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/network_connection/sysmon_wuauclt_network_connection.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/f16aca7a353bb01d9862ea1f2a10fa0d866e83c3/rules/windows/process_creation/sysmon_proxy_execution_wuauclt.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/30bee7204cc1b98a47635ed8e52f44fdf776c602/rules/windows/process_creation/win_susp_wuauclt.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c649a6c7-cd8c-4a78-9c04-000fc76df954
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20af77cf95-c469-471c-b6a0-946c685c4798
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d7825193-b70a-48a4-b992-8b5b3015cc11
   - IOC: wuauclt run with a parameter of a DLL path
   - IOC: Suspicious wuauclt Internet/network connections
 Resources:

--- a/yml/OSBinaries/Xwizard.yml
+++ b/yml/OSBinaries/Xwizard.yml
@@ -31,8 +31,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_class_exec_xwizard.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/8909eefb90c799fb642f6d9d0d6ee6d855a6a654/rules/windows/process_creation/win_dll_sideload_xwizard.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2053d4bb30-3f36-4e8a-b078-69d36c4a79ff
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20193d5ccd-6f59-40c6-b5b0-8e32d5ddd3d1
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/execution_com_object_xwizard.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
 Resources:

--- a/yml/OSBinaries/fsutil.yml
+++ b/yml/OSBinaries/fsutil.yml
@@ -24,7 +24,7 @@ Full_Path:
 Detection:
   - IOC: fsutil.exe should not be run on a normal workstation
   - IOC: file setZeroData (not case-sensitive) in the process arguments
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff5102832031425f6eed011dd3a2e62653008c94/rules/windows/process_creation/proc_creation_win_susp_fsutil_usage.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20add64136-62e5-48ea-807e-88638d02df1e
 Acknowledgement:
   - Person: Elliot Killick
     Handle: '@elliotkillick'

--- a/yml/OSBinaries/wt.yml
+++ b/yml/OSBinaries/wt.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_<version_packageid>\wt.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/add077b8f54474cbfa859cf45a1ca62be5462b0f/rules/windows/process_creation/proc_creation_win_windows_terminal_susp_children.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%208de89e52-f6e1-4b5b-afd1-41ecfa300d48
 Resources:
   - Link: https://twitter.com/nas_bench/status/1552100271668469761
 Acknowledgement:

--- a/yml/OSLibraries/Advpack.yml
+++ b/yml/OSLibraries/Advpack.yml
@@ -46,7 +46,7 @@ Code_Sample:
   - Code: https://github.com/LOLBAS-Project/LOLBAS-Project.github.io/blob/master/_lolbas/Libraries/Payload/Advpack.inf
   - Code: https://github.com/LOLBAS-Project/LOLBAS-Project.github.io/blob/master/_lolbas/Libraries/Payload/Advpack_calc.sct
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_rundll32_application_control_bypass___advpack.yml
 Resources:
   - Link: https://bohops.com/2018/02/26/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence/

--- a/yml/OSLibraries/Desk.yml
+++ b/yml/OSLibraries/Desk.yml
@@ -22,9 +22,9 @@ Full_Path:
   - Path: C:\Windows\System32\desk.cpl
   - Path: C:\Windows\SysWOW64\desk.cpl
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/1d7ee1cd197d3b35508e2a5bf34d9d3b6ca4f504/rules/windows/file/file_event/file_event_win_new_src_file.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/1f8e37351e7c5d89ce7808391edaef34bd8db6c0/rules/windows/process_creation/proc_creation_win_lolbin_rundll32_installscreensaver.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/940f89d43dbac5b7108610a5bde47cda0d2a643b/rules/windows/registry/registry_set/registry_set_scr_file_executed_by_rundll32.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c048f047-7e2a-4888-b302-55f509d4a91d
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2015bd98ea-55f4-4d37-b09a-e7caa0fa2221
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2040b6e656-4e11-4c0c-8772-c1cc6dae34ce
 Resources:
   - Link: https://vxug.fakedoma.in/zines/29a/29a7/Articles/29A-7.030.txt
   - Link: https://twitter.com/pabraeken/status/998627081360695297

--- a/yml/OSLibraries/Dfshim.yml
+++ b/yml/OSLibraries/Dfshim.yml
@@ -19,7 +19,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
 Resources:
   - Link: https://github.com/api0cradle/ShmooCon-2015/blob/master/ShmooCon-2015-Simple-WLEvasion.pdf
   - Link: https://stackoverflow.com/questions/13312273/clickonce-runtime-dfsvc-exe

--- a/yml/OSLibraries/Ieadvpack.yml
+++ b/yml/OSLibraries/Ieadvpack.yml
@@ -46,7 +46,7 @@ Code_Sample:
   - Code: https://github.com/LOLBAS-Project/LOLBAS-Project.github.io/blob/master/_lolbas/Libraries/Payload/Ieadvpack.inf
   - Code: https://github.com/LOLBAS-Project/LOLBAS-Project.github.io/blob/master/_lolbas/Libraries/Payload/Ieadvpack_calc.sct
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_rundll32_application_control_bypass___advpack.yml
 Resources:
   - Link: https://bohops.com/2018/03/10/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence-part-2/

--- a/yml/OSLibraries/Ieframe.yml
+++ b/yml/OSLibraries/Ieframe.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.githubusercontent.com/bohops/89d7b11fa32062cfe31be9fdb18f050e/raw/1206a613a6621da21e7fd164b80a7ff01c5b64ab/calc.url
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
 Resources:
   - Link: http://www.hexacorn.com/blog/2018/03/15/running-programs-via-proxy-jumping-on-a-edr-bypass-trampoline-part-5/
   - Link: https://bohops.com/2018/03/17/abusing-exported-functions-and-exposed-dcom-interfaces-for-pass-thru-command-execution-and-lateral-movement/

--- a/yml/OSLibraries/Mshtml.yml
+++ b/yml/OSLibraries/Mshtml.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
 Resources:
   - Link: https://twitter.com/pabraeken/status/998567549670477824
   - Link: https://windows10dll.nirsoft.net/mshtml_dll.html

--- a/yml/OSLibraries/Pcwutl.yml
+++ b/yml/OSLibraries/Pcwutl.yml
@@ -18,7 +18,7 @@ Code_Sample:
   - Code:
 Detection:
   - Analysis: https://redcanary.com/threat-detection-report/techniques/rundll32/
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
 Resources:
   - Link: https://twitter.com/harr0ey/status/989617817849876488
   - Link: https://windows10dll.nirsoft.net/pcwutl_dll.html

--- a/yml/OSLibraries/Setupapi.yml
+++ b/yml/OSLibraries/Setupapi.yml
@@ -27,8 +27,8 @@ Code_Sample:
   - Code: https://gist.githubusercontent.com/enigma0x3/469d82d1b7ecaf84f4fb9e6c392d25ba/raw/6cb52b88bcc929f5555cd302d9ed848b7e407052/Backdoor-Minimalist.sct
   - Code: https://gist.githubusercontent.com/bohops/0cc6586f205f3691e04a1ebf1806aabd/raw/baf7b29891bb91e76198e30889fbf7d6642e8974/calc_exe.inf
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_setupapi_installhinfsection.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20285b85b1-a555-4095-8652-a8a4106af63f
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_rundll32_application_control_bypass___setupapi.yml
 Resources:
   - Link: https://github.com/huntresslabs/evading-autoruns

--- a/yml/OSLibraries/Shdocvw.yml
+++ b/yml/OSLibraries/Shdocvw.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.githubusercontent.com/bohops/89d7b11fa32062cfe31be9fdb18f050e/raw/1206a613a6621da21e7fd164b80a7ff01c5b64ab/calc.url
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
 Resources:
   - Link: http://www.hexacorn.com/blog/2018/03/15/running-programs-via-proxy-jumping-on-a-edr-bypass-trampoline-part-5/
   - Link: https://bohops.com/2018/03/17/abusing-exported-functions-and-exposed-dcom-interfaces-for-pass-thru-command-execution-and-lateral-movement/

--- a/yml/OSLibraries/Shell32.yml
+++ b/yml/OSLibraries/Shell32.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
   - Splunk: https://github.com/splunk/security_content/blob/a1afa0fa605639cbef7d528dec46ce7c8112194a/detections/endpoint/rundll32_control_rundll_hunt.yml
 Resources:
   - Link: https://twitter.com/Hexacorn/status/885258886428725250

--- a/yml/OSLibraries/Syssetup.yml
+++ b/yml/OSLibraries/Syssetup.yml
@@ -26,7 +26,7 @@ Code_Sample:
   - Code: https://gist.github.com/enigma0x3/469d82d1b7ecaf84f4fb9e6c392d25ba#file-backdoor-minimalist-sct
   - Code: https://gist.github.com/homjxi0e/87b29da0d4f504cb675bb1140a931415
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/detect_rundll32_application_control_bypass___syssetup.yml
 Resources:
   - Link: https://twitter.com/pabraeken/status/994392481927258113

--- a/yml/OSLibraries/Url.yml
+++ b/yml/OSLibraries/Url.yml
@@ -52,7 +52,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
 Resources:
   - Link: https://bohops.com/2018/03/17/abusing-exported-functions-and-exposed-dcom-interfaces-for-pass-thru-command-execution-and-lateral-movement/
   - Link: https://twitter.com/DissectMalware/status/995348436353470465

--- a/yml/OSLibraries/Zipfldr.yml
+++ b/yml/OSLibraries/Zipfldr.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_rundll32_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20e593cf51-88db-4ee1-b920-37e89012a3c9
 Resources:
   - Link: https://twitter.com/moriarty_meng/status/977848311603380224
   - Link: https://twitter.com/bohops/status/997896811904929792

--- a/yml/OSLibraries/comsvcs.yml
+++ b/yml/OSLibraries/comsvcs.yml
@@ -16,9 +16,9 @@ Full_Path:
 Code_Sample:
   - Code: https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/1ff5e226ad8bed34916c16ccc77ba281ca3203ae/rules/windows/process_creation/win_process_dump_rundll32_comsvcs.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/b81839e3ce507df925d6e583e569e1ac3a3894ab/rules/windows/process_access/sysmon_lsass_dump_comsvcs_dll.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_comsvcs_procdump.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20646ea171-dded-4578-8a4d-65e9822892e3
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20a49fa4d5-11db-418c-8473-1e014a8dd462
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2009e6d5c0-05b8-4ff8-9eeb-043046ec774c
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/dump_lsass_via_comsvcs_dll.yml
 Resources:

--- a/yml/OSScripts/CL_LoadAssembly.yml
+++ b/yml/OSScripts/CL_LoadAssembly.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff6c54ded6b52f379cec11fe17c1ccb956faa660/rules/windows/process_creation/proc_creation_win_lolbas_cl_loadassembly.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c57872c7-614f-4d7f-a40d-b78c8df2d30d
 Resources:
   - Link: https://bohops.com/2018/01/07/executing-commands-and-bypassing-applocker-with-powershell-diagnostic-scripts/
 Acknowledgement:

--- a/yml/OSScripts/CL_mutexverifiers.yml
+++ b/yml/OSScripts/CL_mutexverifiers.yml
@@ -20,7 +20,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff6c54ded6b52f379cec11fe17c1ccb956faa660/rules/windows/process_creation/proc_creation_win_lolbas_cl_mutexverifiers.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%201e0e1a81-e79b-44bc-935b-ddb9c8006b3d
 Resources:
   - Link: https://twitter.com/pabraeken/status/995111125447577600
 Acknowledgement:

--- a/yml/OSScripts/Cl_invocation.yml
+++ b/yml/OSScripts/Cl_invocation.yml
@@ -18,9 +18,9 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/2d36d62e88c45a59e22d17849b41ba346a1cb66a/rules/windows/process_creation/win_cl_invocation_lolscript.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/e5b3a1cc14aaad6f2acc569fab9849567f98df3e/rules/windows/powershell/powershell_script/powershell_cl_invocation_lolscript_count.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/e5b3a1cc14aaad6f2acc569fab9849567f98df3e/rules/windows/powershell/powershell_script/powershell_cl_invocation_lolscript.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20a0459f02-ac51-4c09-b511-b8c9203fc429
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20f588e69b-0750-46bb-8f87-0e9320d57536
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204cd29327-685a-460e-9dac-c3ab96e549dc
 Resources:
   - Link:
 Acknowledgement:

--- a/yml/OSScripts/Launch-VsDevShell.yml
+++ b/yml/OSScripts/Launch-VsDevShell.yml
@@ -22,7 +22,7 @@ Full_Path:
   - Path: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\Launch-VsDevShell.ps1
   - Path: C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6199a703221a98ae6ad343c79c558da375203e4e/rules/windows/process_creation/proc_creation_win_lolbin_launch_vsdevshell.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2045d3a03d-f441-458c-8883-df101a3bb146
 Resources:
   - Link: https://twitter.com/nas_bench/status/1535981653239255040
 Acknowledgement:

--- a/yml/OSScripts/Manage-bde.yml
+++ b/yml/OSScripts/Manage-bde.yml
@@ -23,7 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/3107ede1c4d253c89a26f3a0be79122a3a562f29/rules/windows/process_creation/win_manage_bde_lolbas.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c363385c-f75d-4753-a108-c1a8e28bdbda
   - IOC: Manage-bde.wsf should not be invoked by a standard user under normal situations
 Resources:
   - Link: https://gist.github.com/bohops/735edb7494fe1bd1010d67823842b712

--- a/yml/OSScripts/Pubprn.yml
+++ b/yml/OSScripts/Pubprn.yml
@@ -18,7 +18,7 @@ Code_Sample:
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSScripts/Payload/Pubprn_calc.sct
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff5102832031425f6eed011dd3a2e62653008c94/rules/windows/process_creation/proc_creation_win_lolbin_pubprn.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%201fb76ab8-fa60-4b01-bddd-71e89bf555da
 Resources:
   - Link: https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/
   - Link: https://www.slideshare.net/enigma0x3/windows-operating-system-archaeology

--- a/yml/OSScripts/Syncappvpublishingserver.yml
+++ b/yml/OSScripts/Syncappvpublishingserver.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/973e0666acffb8fd7ea8356449eb916381ab0cc6/rules/windows/process_creation/process_creation_syncappvpublishingserver_vbs_execute_powershell.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2036475a7d-0f6d-4dce-9b01-6aeb473bbaf1
 Resources:
   - Link: https://twitter.com/monoxgas/status/895045566090010624
   - Link: https://twitter.com/subTee/status/855738126882316288

--- a/yml/OSScripts/UtilityFunctions.yml
+++ b/yml/OSScripts/UtilityFunctions.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0.21-688-gd172b136b/rules/windows/process_creation/proc_creation_win_lolbas_utilityfunctions.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200403d67d-6227-4ea8-8145-4e72db7da120
 Resources:
   - Link: https://twitter.com/nickvangilder/status/1441003666274668546
 Acknowledgement:

--- a/yml/OSScripts/Winrm.yml
+++ b/yml/OSScripts/Winrm.yml
@@ -32,9 +32,9 @@ Code_Sample:
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSScripts/Payload/Slmgr.reg
   - Code: https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/OSScripts/Payload/Slmgr_calc.sct
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/10b70edff055cfb12b16d934c77f9ccf4b97a529/rules/windows/process_creation/win_susp_winrm_awl_bypass.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/process_creation/win_susp_winrm_execution.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/3107ede1c4d253c89a26f3a0be79122a3a562f29/rules/windows/file_event/file_event_winrm_awl_bypass.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20074e0ded-6ced-4ebd-8b4d-53f55908119d
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209df0dd3a-1a5c-47e3-a2bc-30ed177646a0
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d353dac0-1b41-46c2-820c-d7d2561fc6ed
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
 Resources:
   - Link: https://www.slideshare.net/enigma0x3/windows-operating-system-archaeology

--- a/yml/OSScripts/pester.yml
+++ b/yml/OSScripts/pester.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_pester.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2059e938ff-0d6d-4dc3-b13f-36cc28734d4e
 Resources:
   - Link: https://twitter.com/Oddvarmoe/status/993383596244258816
   - Link: https://twitter.com/_st0pp3r_/status/1560072680887525378

--- a/yml/OtherMSBinaries/AccCheckConsole.yml
+++ b/yml/OtherMSBinaries/AccCheckConsole.yml
@@ -26,7 +26,7 @@ Full_Path:
 Code_Sample:
   - Code: https://docs.microsoft.com/en-us/windows/win32/winauto/custom-verification-routines
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_susp_acccheckconsole.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200f6da907-5854-4be6-859a-e9958747b0aa
   - IOC: Sysmon Event ID 1 - Process Creation
   - Analysis: https://gist.github.com/bohops/2444129419c8acf837aedda5f0e7f340
 Resources:

--- a/yml/OtherMSBinaries/Adplus.yml
+++ b/yml/OtherMSBinaries/Adplus.yml
@@ -38,7 +38,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.github.com/nasbench/e34ca2cd90e3a845a558a102a4f607da
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6199a703221a98ae6ad343c79c558da375203e4e/rules/windows/process_creation/proc_creation_win_lolbin_adplus.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%202f869d59-7f6a-4931-992c-cce556ff2d53
   - IOC: As a Windows SDK binary, execution on a system may be suspicious
 Resources:
   - Link: https://mrd0x.com/adplus-debugging-tool-lsass-dump/

--- a/yml/OtherMSBinaries/Agentexecutor.yml
+++ b/yml/OtherMSBinaries/Agentexecutor.yml
@@ -23,8 +23,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_agentexecutor.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_agentexecutor_susp_usage.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%207efd2c8d-8b18-45b7-947d-adfe9ed04f61
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20c0b40568-b1e9-4b03-8d6c-b096da6da9ab
 Resources:
   - Link:
 Acknowledgement:

--- a/yml/OtherMSBinaries/Appvlp.yml
+++ b/yml/OtherMSBinaries/Appvlp.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/8b170ff5628376c87632635a5fde4e48bba70275/rules/windows/builtin/win_asr_bypass_via_appvlp_re.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%209c7e131a-0f2c-4ae0-9d43-b04f4e266d43
 Resources:
   - Link: https://github.com/MoooKitty/Code-Execution
   - Link: https://twitter.com/moo_hax/status/892388990686347264

--- a/yml/OtherMSBinaries/Bginfo.yml
+++ b/yml/OtherMSBinaries/Bginfo.yml
@@ -51,7 +51,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_bginfo.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20aaf46cdc-934e-4284-b329-34aa701e3771
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules

--- a/yml/OtherMSBinaries/Cdb.yml
+++ b/yml/OtherMSBinaries/Cdb.yml
@@ -33,7 +33,7 @@ Full_Path:
 Code_Sample:
   - Code: https://gist.github.com/nasbench/d9c15864f1e21bdd8b7cf55997b45f4b
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_cdb.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b5c7395f-e501-4a08-94d4-57fe7a9da9d2
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules

--- a/yml/OtherMSBinaries/Createdump.yml
+++ b/yml/OtherMSBinaries/Createdump.yml
@@ -17,8 +17,8 @@ Full_Path:
   - Path: C:\Program Files\Microsoft Visual Studio\*\Community\dotnet\runtime\shared\Microsoft.NETCore.App\6.0.0\createdump.exe
   - Path: C:\Program Files (x86)\Microsoft Visual Studio\*\Community\dotnet\runtime\shared\Microsoft.NETCore.App\6.0.0\createdump.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_proc_dump_createdump.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_susp_renamed_createdump.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20515c8be5-e5df-4c5e-8f6d-a4a2f05e4b48
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%201a1ed54a-2ba4-4221-94d5-01dee560d71e
   - IOC: createdump.exe process with a command line containing the lsass.exe process id
 Resources:
   - Link: https://twitter.com/bopin2020/status/1366400799199272960

--- a/yml/OtherMSBinaries/Csi.yml
+++ b/yml/OtherMSBinaries/Csi.yml
@@ -17,8 +17,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/process_creation/win_susp_csi.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_use_of_csharp_console.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2040b95d31-1afc-469e-8d34-9a3a667d058e
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20a9e416a8-e613-4f8b-88b8-a7d1d1af2f61
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules

--- a/yml/OtherMSBinaries/Devtoolslauncher.yml
+++ b/yml/OtherMSBinaries/Devtoolslauncher.yml
@@ -23,7 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_devtoolslauncher.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20cc268ac1-42d9-40fd-9ed3-8c4e1a5b87e6
   - IOC: DeveloperToolsSvc.exe spawned an unknown process
 Resources:
   - Link: https://twitter.com/_felamos/status/1179811992841797632

--- a/yml/OtherMSBinaries/Dnx.yml
+++ b/yml/OtherMSBinaries/Dnx.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_dnx.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2081ebd28b-9607-4478-bf06-974ed9d53ed7
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules

--- a/yml/OtherMSBinaries/Dotnet.yml
+++ b/yml/OtherMSBinaries/Dotnet.yml
@@ -35,7 +35,7 @@ Commands:
 Full_Path:
   - Path: 'C:\Program Files\dotnet\dotnet.exe'
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/0bf262539301693a18646056ea789b9b56b9c7f6/rules/windows/process_creation/process_creation_dotnet.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20d80d5c81-04ba-45b4-84e4-92eba40e0ad3
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: dotnet.exe spawned an unknown process
 Resources:

--- a/yml/OtherMSBinaries/Dump64.yml
+++ b/yml/OtherMSBinaries/Dump64.yml
@@ -14,7 +14,7 @@ Commands:
 Full_Path:
   - Path: C:\Program Files (x86)\Microsoft Visual Studio\Installer\Feedback\dump64.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/138b06628380468fb8a41fc27770e1630cb64326/rules/windows/process_creation/process_creation_win_lolbas_dump64.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20129966c9-de17-4334-a123-8b58172e664d
   - IOC: As a Windows SDK binary, execution on a system may be suspicious
 Resources:
   - Link: https://twitter.com/mrd0x/status/1460597833917251595

--- a/yml/OtherMSBinaries/Dxcap.yml
+++ b/yml/OtherMSBinaries/Dxcap.yml
@@ -17,7 +17,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_dxcap.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2060f16a96-db70-42eb-8f76-16763e333590
 Resources:
   - Link: https://twitter.com/harr0ey/status/992008180904419328
 Acknowledgement:

--- a/yml/OtherMSBinaries/Excel.yml
+++ b/yml/OtherMSBinaries/Excel.yml
@@ -30,7 +30,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_msoffice.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200c79148b-118e-472b-bdb7-9b57b444cc19
   - IOC: Suspicious Office application Internet/network traffic
 Resources:
   - Link: https://twitter.com/reegun21/status/1150032506504151040

--- a/yml/OtherMSBinaries/Fsi.yml
+++ b/yml/OtherMSBinaries/Fsi.yml
@@ -27,7 +27,7 @@ Detection:
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: Fsi.exe execution may be suspicious on non-developer machines
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6b34764215b0e97e32cbc4c6325fc933d2695c3a/rules/windows/process_creation/proc_creation_win_lolbin_fsharp_interpreters.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b96b2031-7c17-4473-afe7-a30ce714db29
 Resources:
   - Link: https://twitter.com/NickTyrer/status/904273264385589248
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/

--- a/yml/OtherMSBinaries/FsiAnyCpu.yml
+++ b/yml/OtherMSBinaries/FsiAnyCpu.yml
@@ -25,7 +25,7 @@ Code_Sample:
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: FsiAnyCpu.exe execution may be suspicious on non-developer machines
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6b34764215b0e97e32cbc4c6325fc933d2695c3a/rules/windows/process_creation/proc_creation_win_lolbin_fsharp_interpreters.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b96b2031-7c17-4473-afe7-a30ce714db29
 Resources:
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Mftrace.yml
+++ b/yml/OtherMSBinaries/Mftrace.yml
@@ -26,7 +26,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_mftrace.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%203d48c9d3-1aa6-418d-98d3-8fd3c01a564e
 Resources:
   - Link: https://twitter.com/0rbz_/status/988911181422186496
 Acknowledgement:

--- a/yml/OtherMSBinaries/Msdeploy.yml
+++ b/yml/OtherMSBinaries/Msdeploy.yml
@@ -23,7 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/f16aca7a353bb01d9862ea1f2a10fa0d866e83c3/rules/windows/process_creation/process_creation_msdeploy.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20646bc99f-6682-4b47-a73a-17b1b64c9d34
 Resources:
   - Link: https://twitter.com/pabraeken/status/995837734379032576
   - Link: https://twitter.com/pabraeken/status/999090532839313408

--- a/yml/OtherMSBinaries/MsoHtmEd.yml
+++ b/yml/OtherMSBinaries/MsoHtmEd.yml
@@ -28,7 +28,7 @@ Full_Path:
   - Path: C:\Program Files\Microsoft Office\Office12\MSOHTMED.exe
   - Path: C:\Program Files\Microsoft Office\Office12\MSOHTMED.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_msohtmed_download.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20459f2f98-397b-4a4a-9f47-6a5ec2f1c69d
   - IOC: Suspicious Office application internet/network traffic
 Acknowledgement:
   - Person: Nir Chako (Pentera)

--- a/yml/OtherMSBinaries/Mspub.yml
+++ b/yml/OtherMSBinaries/Mspub.yml
@@ -25,7 +25,7 @@ Full_Path:
   - Path: C:\Program Files (x86)\Microsoft Office\Office14\MSPUB.exe
   - Path: C:\Program Files\Microsoft Office\Office14\MSPUB.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_mspub_download.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%203b3c7f55-f771-4dd6-8a6e-08d057a17caf
   - IOC: Suspicious Office application internet/network traffic
 Acknowledgement:
   - Person: 'Nir Chako (Pentera)'

--- a/yml/OtherMSBinaries/Msxsl.yml
+++ b/yml/OtherMSBinaries/Msxsl.yml
@@ -37,7 +37,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/ff0f1a0222b5100120ae3e43df18593f904c69c0/rules/windows/process_creation/win_xsl_script_processing.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2005c36dd6-79d6-4a9a-97da-3db20298ab2d
   - Elastic: https://github.com/elastic/detection-rules/blob/cc241c0b5ec590d76cb88ec638d3cc37f68b5d50/rules/windows/defense_evasion_msxsl_beacon.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/12577f7380f324fcee06dab3218582f4a11833e7/rules/windows/defense_evasion_msxsl_network.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml

--- a/yml/OtherMSBinaries/Ntdsutil.yml
+++ b/yml/OtherMSBinaries/Ntdsutil.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_ntdsutil.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%202afafd61-6aae-4df4-baed-139fa1f4c345
   - Splunk: https://github.com/splunk/security_content/blob/2b87b26bdc2a84b65b1355ffbd5174bdbdb1879c/detections/endpoint/ntdsutil_export_ntds.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
   - IOC: ntdsutil.exe with command line including "ifm"

--- a/yml/OtherMSBinaries/OpenConsole.yml
+++ b/yml/OtherMSBinaries/OpenConsole.yml
@@ -17,7 +17,7 @@ Full_Path:
   - Path: C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\Terminal\ServiceHub\os64\OpenConsole.exe
 Detection:
   - IOC: OpenConsole.exe spawning unexpected processes
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/9e0ef7251b075f15e7abafbbec16d3230c5fa477/rules/windows/process_creation/proc_creation_win_lolbin_openconsole.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20814c95cc-8192-4378-a70a-f1aafd877af1
 Resources:
   - Link: https://twitter.com/nas_bench/status/1537563834478645252
 Acknowledgement:

--- a/yml/OtherMSBinaries/Powerpnt.yml
+++ b/yml/OtherMSBinaries/Powerpnt.yml
@@ -28,7 +28,7 @@ Full_Path:
   - Path: C:\Program Files\Microsoft Office\Office12\Powerpnt.exe
   - Path: C:\Program Files\Microsoft Office\Office12\Powerpnt.exe
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/8bb3379b6807610d61d29db1d76f5af4840b8208/rules/windows/process_creation/proc_creation_win_susp_msoffice.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200c79148b-118e-472b-bdb7-9b57b444cc19
   - IOC: Suspicious Office application Internet/network traffic
 Resources:
   - Link: https://twitter.com/reegun21/status/1150032506504151040

--- a/yml/OtherMSBinaries/Procdump.yml
+++ b/yml/OtherMSBinaries/Procdump.yml
@@ -23,8 +23,8 @@ Commands:
 Full_Path:
   - Path: no default
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/f36b1cbd2a3f1a7423f43a67a182549778700615/rules/windows/process_creation/win_susp_procdump.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/f36b1cbd2a3f1a7423f43a67a182549778700615/rules/windows/process_creation/win_procdump.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2003795938-1387-481b-9f4c-3f6241e604fe
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%202e65275c-8288-4ab4-aeb7-6274f58b6b20
   - Splunk: https://github.com/splunk/security_content/blob/86a5b644a44240f01274c8b74d19a435c7dae66e/detections/endpoint/dump_lsass_via_procdump.yml
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
   - IOC: Process creation with given '-md' parameter

--- a/yml/OtherMSBinaries/Rcsi.yml
+++ b/yml/OtherMSBinaries/Rcsi.yml
@@ -23,10 +23,10 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/process_creation/win_susp_csi.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2040b95d31-1afc-469e-8d34-9a3a667d058e
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_unusual_process_network_connection.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/414d32027632a49fb239abb8fbbb55d3fa8dd861/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
-  - BlockRule: https://github.com/SigmaHQ/sigma/blob/7bca85e40618126643b9712b80bd663c21908e26/rules/windows/process_creation/win_susp_csi.yml
+  - BlockRule: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2040b95d31-1afc-469e-8d34-9a3a667d058e
 Resources:
   - Link: https://enigma0x3.net/2016/11/21/bypassing-application-whitelisting-by-using-rcsi-exe/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Remote.yml
+++ b/yml/OtherMSBinaries/Remote.yml
@@ -32,7 +32,7 @@ Code_Sample:
   - Code:
 Detection:
   - IOC: remote.exe process spawns
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/197615345b927682ab7ad7fa3c5f5bb2ed911eed/rules/windows/process_creation/proc_creation_win_lolbin_remote.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204eddc365-79b4-43ff-a9d7-99422dc34b93
 Resources:
   - Link: https://blog.thecybersecuritytutor.com/Exeuction-AWL-Bypass-Remote-exe-LOLBin/
 Acknowledgement:

--- a/yml/OtherMSBinaries/Sqldumper.yml
+++ b/yml/OtherMSBinaries/Sqldumper.yml
@@ -24,7 +24,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_sqldumper_activity.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2023ceaf5c-b6f1-4a32-8559-f2ff734be516
   - Elastic: https://github.com/elastic/detection-rules/blob/f6421d8c534f295518a2c945f530e8afc4c8ad1b/rules/windows/credential_access_lsass_memdump_file_created.toml
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/credential_access_cmdline_dump_tool.toml
 Resources:

--- a/yml/OtherMSBinaries/Sqlps.yml
+++ b/yml/OtherMSBinaries/Sqlps.yml
@@ -20,8 +20,8 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_use_of_sqlps_bin.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/80d2aee9449050652ca02fe8892e7bc23de3b70c/rules/windows/image_load/sysmon_in_memory_powershell.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%200152550d-3a26-4efd-9f0e-54a0b28ae2f3
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20092bc4b9-3d1d-43b4-a6b4-8c8acd83522f
   - Elastic: https://github.com/elastic/detection-rules/blob/5bdf70e72c6cd4547624c521108189af994af449/rules/windows/execution_suspicious_powershell_imgload.toml
   - Splunk: https://github.com/splunk/security_content/blob/aa9f7e0d13a61626c69367290ed1b7b71d1281fd/docs/_posts/2021-10-05-suspicious_copy_on_system32.md
 Resources:

--- a/yml/OtherMSBinaries/Sqltoolsps.yml
+++ b/yml/OtherMSBinaries/Sqltoolsps.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_use_of_sqltoolsps_bin.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20a746c9b8-a2fb-4ee5-a428-92bee9e99060
   - Splunk: https://github.com/splunk/security_content/blob/aa9f7e0d13a61626c69367290ed1b7b71d1281fd/docs/_posts/2021-10-05-suspicious_copy_on_system32.md
 Resources:
   - Link: https://twitter.com/pabraeken/status/993298228840992768

--- a/yml/OtherMSBinaries/Squirrel.yml
+++ b/yml/OtherMSBinaries/Squirrel.yml
@@ -44,8 +44,8 @@ Full_Path:
 Code_Sample:
   - Code: https://github.com/jreegun/POC-s/tree/master/nuget-squirrel
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_squirrel.yml
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_susp_squirrel_lolbin.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2045239e6a-b035-4aaf-b339-8ad379fcb67e
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fa4b21c9-0057-4493-b289-2556416ae4d7
 Resources:
   - Link: https://www.youtube.com/watch?v=rOP3hnkj7ls
   - Link: https://twitter.com/reegun21/status/1144182772623269889

--- a/yml/OtherMSBinaries/Te.yml
+++ b/yml/OtherMSBinaries/Te.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_use_of_te_bin.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20634b00d5-ccc3-4a06-ae3b-0ec8444dd51b
 Resources:
   - Link: https://twitter.com/gn3mes1s/status/927680266390384640?lang=bg
 Acknowledgement:

--- a/yml/OtherMSBinaries/Tracker.yml
+++ b/yml/OtherMSBinaries/Tracker.yml
@@ -23,7 +23,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_tracker_execution.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20148431ce-4b70-403d-8525-fcc2993f29ea
 Resources:
   - Link: https://twitter.com/subTee/status/793151392185589760
   - Link: https://attack.mitre.org/wiki/Execution

--- a/yml/OtherMSBinaries/Update.yml
+++ b/yml/OtherMSBinaries/Update.yml
@@ -100,7 +100,7 @@ Full_Path:
 Code_Sample:
   - Code: https://github.com/jreegun/POC-s/tree/master/nuget-squirrel
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/win_susp_squirrel_lolbin.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20fa4b21c9-0057-4493-b289-2556416ae4d7
   - IOC: Update.exe spawned an unknown process
 Resources:
   - Link: https://www.youtube.com/watch?v=rOP3hnkj7ls

--- a/yml/OtherMSBinaries/VSIISExeLauncher.yml
+++ b/yml/OtherMSBinaries/VSIISExeLauncher.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_vsiisexelauncher.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2018749301-f1c5-4efc-a4c3-276ff1f5b6f8
   - IOC: VSIISExeLauncher.exe spawned an unknown process
 Resources:
   - Link: https://github.com/timwhitez

--- a/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
+++ b/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
@@ -18,7 +18,7 @@ Code_Sample:
   - Code:
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6b34764215b0e97e32cbc4c6325fc933d2695c3a/rules/windows/process_creation/proc_creation_win_lolbin_visualuiaverifynative.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20b30a8bc5-e21b-4ca2-9420-0a94019ac56a
   - IOC: As a Windows SDK binary, execution on a system may be suspicious
 Resources:
   - Link: https://bohops.com/2020/10/15/exploring-the-wdac-microsoft-recommended-block-rules-visualuiaverifynative/

--- a/yml/OtherMSBinaries/Vsjitdebugger.yml
+++ b/yml/OtherMSBinaries/Vsjitdebugger.yml
@@ -16,7 +16,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/8beb70e970b814d0ab60625206ea0d8a21a9bff8/rules/windows/process_creation/win_susp_use_of_vsjitdebugger_bin.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2015c7904e-6ad1-4a45-9b46-5fb25df37fd2
 Resources:
   - Link: https://twitter.com/pabraeken/status/990758590020452353
 Acknowledgement:

--- a/yml/OtherMSBinaries/Wfc.yml
+++ b/yml/OtherMSBinaries/Wfc.yml
@@ -17,7 +17,7 @@ Code_Sample:
   - Code: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/6b34764215b0e97e32cbc4c6325fc933d2695c3a/rules/windows/process_creation/proc_creation_win_lolbin_wfc.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%2049be8799-7b4d-4fda-ad23-cafbefdebbc5
   - IOC: As a Windows SDK binary, execution on a system may be suspicious
 Resources:
   - Link: https://bohops.com/2020/11/02/exploring-the-wdac-microsoft-recommended-block-rules-part-ii-wfc-fsi/

--- a/yml/OtherMSBinaries/Winword.yml
+++ b/yml/OtherMSBinaries/Winword.yml
@@ -31,7 +31,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/19396788dbedc57249a46efed2bb1927abc376d4/rules/windows/process_creation/proc_creation_win_lolbin_winword.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%204ae3e30b-b03f-43aa-87e3-b622f4048eed
   - IOC: Suspicious Office application Internet/network traffic
 Resources:
   - Link: https://twitter.com/reegun21/status/1150032506504151040

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -44,7 +44,7 @@ Full_Path:
 Code_Sample:
   - Code:
 Detection:
-  - Sigma: https://github.com/SigmaHQ/sigma/blob/2a4e6d8ebeb07d294e6d16a083361bd7e53df7b3/rules/windows/process_creation/proc_creation_win_lolbin_susp_wsl.yml
+  - Sigma: https://github.com/search?q=repo%3ASigmaHQ%2Fsigma%20dec44ca7-61ad-493c-bfd7-8819c5faa09b
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: Child process from wsl.exe
 Resources:


### PR DESCRIPTION
from static reference to commit to sgithub earch on the sigma based on the rule UUID.
The goals are:
1) avoid linking to a snapshot in time of the rules (because of using blob IDs)
2) handle rule renaming/moving the repo.
3) show all the details related to the rule (the file, and discussions, PRs, issues) in one go, if they mention the UUID.