### PR TITLE
Add missing document starts and add yamllint rule

### DIFF
--- a/.github/.yamllint
+++ b/.github/.yamllint
@@ -13,3 +13,6 @@ rules:
     level: error
   indentation:
     level: error
+  document-start:
+    present: true
+    level: error

--- a/yml/OSBinaries/Ssh.yml
+++ b/yml/OSBinaries/Ssh.yml
@@ -1,3 +1,4 @@
+---
 Name: ssh.exe
 Description: Ssh.exe is the OpenSSH compatible client can be used to connect to Windows 10 (build 1809 and later) and Windows Server 2019 devices.
 Author: 'Akshat Pradhan'

--- a/yml/OtherMSBinaries/Fsi.yml
+++ b/yml/OtherMSBinaries/Fsi.yml
@@ -1,3 +1,4 @@
+---
 Name: Fsi.exe
 Description: 64-bit FSharp (F#) Interpreter included with Visual Studio and DotNet Core SDK.
 Author: Jimmy (@bohops)

--- a/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
+++ b/yml/OtherMSBinaries/VisualUiaVerifyNative.yml
@@ -1,3 +1,4 @@
+---
 Name: VisualUiaVerifyNative.exe
 Description: A Windows SDK binary for manual and automated testing of Microsoft UI Automation implementation and controls.
 Author: Jimmy (@bohops)


### PR DESCRIPTION
If there is no --- at the start of the yaml file, they will not be converted to markdown for the lolbas github pages.

As a result, these three pages are currently 404s and do not show up in the site search:

https://lolbas-project.github.io/lolbas/OtherMSBinaries/Fsi/
https://lolbas-project.github.io/lolbas/Binaries/Ssh/
https://lolbas-project.github.io/lolbas/OtherMSBinaries/VisualUiaVerifyNative/

This PR fixes that and adds a yamllint check to verify that new yaml files have the document start. 
