### PR TITLE
Network Information Collector Script

### DIFF
--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -4,7 +4,7 @@ Description: Network Information Collector Script
 Author: Kyaw Pyiyt Htet (@KyawPyiytHtet)
 Created: 2023-08-25
 Commands:
-  - Command: "wscript gatherNetworkInfo.vbs", "wscript gatherNetworkInfo.vbs 'GetOSInfo'"
+  - Command: "wscript gatherNetworkInfo.vbs"
     Description: The script "gathernetworkinfo.vbs" is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in "c:\Windows\System32\config" or "c:\Windows\System32\reg".
     Usecase: Execute proxied payload with Microsoft signed binary
     Category: Execute

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -5,7 +5,7 @@ Author: 'Kyaw Pyiyt Htet'
 Created: 2023-08-25
 Commands:
   - Command: wscript.exe gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information. Outputs are stored in "c:\Windows\System32\config or c:\Windows\System32\reg".
+    Description: The script gathernetworkinfo.vbs is employed to collect system information. Outputs are stored in config or reg directories.
     Category: Execute
     Privileges: User
     MitreID: T1082

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -1,0 +1,20 @@
+---
+Name: gatherNetworkInfo.vbs
+Description: Network Information Collector Script
+Author: Kyaw Pyiyt Htet (@KyawPyiytHtet)
+Created: 2023-08-25
+Commands:
+  - Command: "wscript gatherNetworkInfo.vbs", "wscript gatherNetworkInfo.vbs 'GetOSInfo'"
+    Description: The script "gathernetworkinfo.vbs" is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in "c:\Windows\System32\config" or "c:\Windows\System32\reg".
+    Usecase: Execute proxied payload with Microsoft signed binary
+    Category: Execute
+    Privileges: User
+    MitreID: T1082
+    OperatingSystem: Windows 10, Windows 11
+Full_Path:
+  - Path: c:\Windows\System32\gatherNetworkInfo.vbs
+Resources:
+  - Link: https://www.verboon.info/2011/06/the-gathernetworkinfo-vbs-script/
+Acknowledgement:
+  - Person: Kyaw Pyiyt Htet
+    Handle: '@KyawPyiytHtet'

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -4,7 +4,7 @@ Description: Network Information Collector Script
 Author: Kyaw Pyiyt Htet (@KyawPyiytHtet)
 Created: 2023-08-25
 Commands:
-  - Command: "wscript gatherNetworkInfo.vbs"
+  - Command: wscript gatherNetworkInfo.vbs
     Description: The script "gathernetworkinfo.vbs" is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in "c:\Windows\System32\config" or "c:\Windows\System32\reg".
     Usecase: Execute proxied payload with Microsoft signed binary
     Category: Execute

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -5,7 +5,7 @@ Author: 'Kyaw Pyiyt Htet'
 Created: 2023-08-25
 Commands:
   - Command: wscript.exe gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in c:\Windows\System32\config or c:\Windows\System32\reg.
+    Description: The script gathernetworkinfo.vbs is employed to collect system information and outputs are stored\n in c:\Windows\System32\config or c:\Windows\System32\reg.
     Category: Execute
     Privileges: User
     MitreID: T1082

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -5,7 +5,7 @@ Author: Kyaw Pyiyt Htet (@KyawPyiytHtet)
 Created: 2023-08-25
 Commands:
   - Command: wscript gatherNetworkInfo.vbs
-    Description: The script "gathernetworkinfo.vbs" is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in "c:\Windows\System32\config" or "c:\Windows\System32\reg".
+    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in c:\Windows\System32\config or c:\Windows\System32\reg.
     Usecase: Execute proxied payload with Microsoft signed binary
     Category: Execute
     Privileges: User

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -6,6 +6,7 @@ Created: 2023-08-25
 Commands:
   - Command: wscript.exe gatherNetworkInfo.vbs
     Description: The script gathernetworkinfo.vbs is employed to collect system information.
+    Usecase: Proxy execution
     Category: Execute
     Privileges: User
     MitreID: T1082

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -1,11 +1,11 @@
 ---
 Name: gatherNetworkInfo.vbs
 Description: Network Information Collector Script
-Author: Kyaw Pyiyt Htet (@KyawPyiytHtet)
+Author: 'Kyaw Pyiyt Htet (@KyawPyiytHtet)'
 Created: 2023-08-25
 Commands:
   - Command: wscript gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc.
+    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. utputs are stored in "c:\Windows\System32\config" or "c:\Windows\System32\reg".
     Usecase: Execute proxied payload with Microsoft signed binary
     Category: Execute
     Privileges: User

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -5,7 +5,7 @@ Author: Kyaw Pyiyt Htet (@KyawPyiytHtet)
 Created: 2023-08-25
 Commands:
   - Command: wscript gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in c:\Windows\System32\config or c:\Windows\System32\reg.
+    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc.
     Usecase: Execute proxied payload with Microsoft signed binary
     Category: Execute
     Privileges: User

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -1,10 +1,11 @@
+---
 Name: gatherNetworkInfo.vbs
 Description: Network Information Collector Script
 Author: 'Kyaw Pyiyt Htet'
 Created: 2023-08-25
 Commands:
   - Command: wscript.exe gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in c:\Windows\System32\config or c:\Windows\System32\reg.
+    Description: The script gathernetworkinfo.vbs is employed to collect system information. Outputs are stored in c:\Windows\System32\config or c:\Windows\System32\reg.
     Category: Execute
     Privileges: User
     MitreID: T1082

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -5,15 +5,13 @@ Author: 'Kyaw Pyiyt Htet'
 Created: 2023-08-25
 Commands:
   - Command: wscript.exe gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information and outputs are stored\n in c:\Windows\System32\config or c:\Windows\System32\reg.
+    Description: The script gathernetworkinfo.vbs is employed to collect system information.
     Category: Execute
     Privileges: User
     MitreID: T1082
-    OperatingSystem: Windows 10, Windows 11
+    OperatingSystem: Windows 10
 Full_Path:
-  - Path: c:\Windows\System32\gatherNetworkInfo.vbs
-Code_Sample:
-  - Code:
+  - Path: C:\Windows\System32\gatherNetworkInfo.vbs
 Resources:
   - Link: https://www.verboon.info/2011/06/the-gathernetworkinfo-vbs-script/
 Acknowledgement:

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -1,7 +1,7 @@
 ---
 Name: gatherNetworkInfo.vbs
 Description: Network Information Collector Script
-Author: 'Kyaw Pyiyt Htet (@KyawPyiytHtet)'
+Author: 'Kyaw Pyiyt Htet'
 Created: 2023-08-25
 Commands:
   - Command: wscript gatherNetworkInfo.vbs

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -1,21 +1,24 @@
 ---
 Name: gatherNetworkInfo.vbs
 Description: Network Information Collector Script
-Author: 'Kyaw Pyiyt Htet'
+Author: Kyaw Pyiyt Htet
 Created: 2023-08-25
 Commands:
   - Command: wscript.exe gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information. Outputs are stored in config or reg directories.
+    Description: The script gathernetworkinfo.vbs is employed to collect system
+      information such as the operating system, DNS details, firewall
+      configuration, etc. Outputs are stored in c:\Windows\System32\config or
+      c:\Windows\System32\reg.
     Category: Execute
     Privileges: User
     MitreID: T1082
     OperatingSystem: Windows 10, Windows 11
 Full_Path:
-  - Path: C:\Windows\System32\gatherNetworkInfo.vbs
+  - Path: c:\Windows\System32\gatherNetworkInfo.vbs
 Code_Sample:
-  - Code:
+  - Code: null
 Resources:
   - Link: https://www.verboon.info/2011/06/the-gathernetworkinfo-vbs-script/
 Acknowledgement:
   - Person: Kyaw Pyiyt Htet
-    Handle: '@KyawPyiytHtet'
+    Handle: "@KyawPyiytHtet"

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -5,13 +5,13 @@ Author: 'Kyaw Pyiyt Htet'
 Created: 2023-08-25
 Commands:
   - Command: wscript.exe gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information. Outputs are stored in c:\Windows\System32\config or c:\Windows\System32\reg.
+    Description: The script gathernetworkinfo.vbs is employed to collect system information. Outputs are stored in "c:\Windows\System32\config or c:\Windows\System32\reg".
     Category: Execute
     Privileges: User
     MitreID: T1082
     OperatingSystem: Windows 10, Windows 11
 Full_Path:
-  - Path: c:\Windows\System32\gatherNetworkInfo.vbs
+  - Path: C:\Windows\System32\gatherNetworkInfo.vbs
 Code_Sample:
   - Code:
 Resources:

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -1,18 +1,18 @@
----
 Name: gatherNetworkInfo.vbs
 Description: Network Information Collector Script
 Author: 'Kyaw Pyiyt Htet'
 Created: 2023-08-25
 Commands:
-  - Command: wscript gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. utputs are stored in "c:\Windows\System32\config" or "c:\Windows\System32\reg".
-    Usecase: Execute proxied payload with Microsoft signed binary
+  - Command: wscript.exe gatherNetworkInfo.vbs
+    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in c:\Windows\System32\config or c:\Windows\System32\reg.
     Category: Execute
     Privileges: User
     MitreID: T1082
     OperatingSystem: Windows 10, Windows 11
 Full_Path:
   - Path: c:\Windows\System32\gatherNetworkInfo.vbs
+Code_Sample:
+  - Code:
 Resources:
   - Link: https://www.verboon.info/2011/06/the-gathernetworkinfo-vbs-script/
 Acknowledgement:

--- a/yml/OSScripts/gatherNetworkInfo.yml
+++ b/yml/OSScripts/gatherNetworkInfo.yml
@@ -1,14 +1,11 @@
 ---
 Name: gatherNetworkInfo.vbs
 Description: Network Information Collector Script
-Author: Kyaw Pyiyt Htet
+Author: 'Kyaw Pyiyt Htet'
 Created: 2023-08-25
 Commands:
   - Command: wscript.exe gatherNetworkInfo.vbs
-    Description: The script gathernetworkinfo.vbs is employed to collect system
-      information such as the operating system, DNS details, firewall
-      configuration, etc. Outputs are stored in c:\Windows\System32\config or
-      c:\Windows\System32\reg.
+    Description: The script gathernetworkinfo.vbs is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in c:\Windows\System32\config or c:\Windows\System32\reg.
     Category: Execute
     Privileges: User
     MitreID: T1082
@@ -16,9 +13,9 @@ Commands:
 Full_Path:
   - Path: c:\Windows\System32\gatherNetworkInfo.vbs
 Code_Sample:
-  - Code: null
+  - Code:
 Resources:
   - Link: https://www.verboon.info/2011/06/the-gathernetworkinfo-vbs-script/
 Acknowledgement:
   - Person: Kyaw Pyiyt Htet
-    Handle: "@KyawPyiytHtet"
+    Handle: '@KyawPyiytHtet'


### PR DESCRIPTION
The script "gathernetworkinfo.vbs" is employed to collect system information such as the operating system, DNS details, firewall configuration, etc. Outputs are stored in "c:\Windows\System32\config" or "c:\Windows\System32\reg".