### PR TITLE
DevTunnels - Other MS Binary for Data Exfiltration

### DIFF
--- a/yml/OtherMSBinaries/devtunnels.yml
+++ b/yml/OtherMSBinaries/devtunnels.yml
@@ -16,8 +16,8 @@ Full_Path:
   - Path: C:\Users\<username>\AppData\Local\Temp\DevTunnels
 Detection:
   - IOC: devtunnel.exe binary spawned
-  - IOC: *.devtunnels.ms
-  - IOC: *.*.devtunnels.ms
+  - IOC: '*.devtunnels.ms'
+  - IOC: '*.*.devtunnels.ms'
   - Analysis: https://cydefops.com/vscode-data-exfiltration
 Resources:
   - Link: https://code.visualstudio.com/docs/editor/port-forwarding

--- a/yml/OtherMSBinaries/devtunnels.yml
+++ b/yml/OtherMSBinaries/devtunnels.yml
@@ -8,7 +8,7 @@ Commands:
     Description: Enabling a forwarded port for locally hosted service at port 8080 to be exposed on the internet.
     Usecase: Download Files, Upload Files, Data Exfiltration
     Category: Download
-    Privileges: Outlook account, GitHub account authentication/valid credentials/SSO required.
+    Privileges: User
     MitreID: T1105
     OperatingSystem: Windows 10, Windows 11, MacOS
 Full_Path:

--- a/yml/OtherMSBinaries/devtunnels.yml
+++ b/yml/OtherMSBinaries/devtunnels.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Download Files, Upload Files, Data Exfiltration
     Category: Download
     Privileges: Outlook account, GitHub account authentication/valid credentials/SSO required.
-    MitreID: T1105, T1218, T1048.003
+    MitreID: T1105
     OperatingSystem: Windows 10, Windows 11, MacOS
 Full_Path:
   - Path: C:\Users\<username>\AppData\Local\Temp\.net\devtunnel\

--- a/yml/OtherMSBinaries/devtunnels.yml
+++ b/yml/OtherMSBinaries/devtunnels.yml
@@ -7,7 +7,10 @@ Commands:
   - Command: devtunnel.exe host -p 8080
     Description: Enabling a forwarded port for locally hosted service at port 8080 to be exposed on the internet.
     Usecase: Download Files, Upload Files, Data Exfiltration
-    Category: Download, Upload, Execute, Copy
+    Category: Download
+    Category: Upload
+    Category: Execute
+    Category: Copy
     Privileges: Outlook account, GitHub account authentication/valid credentials/SSO required.
     MitreID: T1105, T1218, T1048.003
     OperatingSystem: Windows 10, Windows 11, MacOS

--- a/yml/OtherMSBinaries/devtunnels.yml
+++ b/yml/OtherMSBinaries/devtunnels.yml
@@ -1,0 +1,26 @@
+---
+Name: devtunnel.exe
+Description: Binary to enable forwarded ports on windows operating systems.
+Author: Kamran Saifullah
+Created: 2023-09-16
+Commands:
+  - Command: devtunnel.exe host -p 8080
+    Description: Enabling a forwarded port for locally hosted service at port 8080 to be exposed on the internet.
+    Usecase: Download Files, Upload Files, Data Exfiltration
+    Category: Download, Upload, Execute, Copy
+    Privileges: Outlook account, GitHub account authentication/valid credentials/SSO required.
+    MitreID: T1105, T1218, T1048.003
+    OperatingSystem: Windows 10, Windows 11, MacOS
+Full_Path:
+  - Path: C:\Users\<username>\AppData\Local\Temp\.net\devtunnel\
+  - Path: C:\Users\<username>\AppData\Local\Temp\DevTunnels
+Detection:
+  - IOC: devtunnel.exe binary spawned
+  - IOC: *.devtunnels.ms
+  - IOC: *.*.devtunnels.ms
+  - Analysis: https://cydefops.com/vscode-data-exfiltration
+Resources:
+  - Link: https://code.visualstudio.com/docs/editor/port-forwarding
+Acknowledgement:
+  - Person: Kamran Saifullah
+    Handle: '@deFr0ggy'

--- a/yml/OtherMSBinaries/devtunnels.yml
+++ b/yml/OtherMSBinaries/devtunnels.yml
@@ -8,9 +8,6 @@ Commands:
     Description: Enabling a forwarded port for locally hosted service at port 8080 to be exposed on the internet.
     Usecase: Download Files, Upload Files, Data Exfiltration
     Category: Download
-    Category: Upload
-    Category: Execute
-    Category: Copy
     Privileges: Outlook account, GitHub account authentication/valid credentials/SSO required.
     MitreID: T1105, T1218, T1048.003
     OperatingSystem: Windows 10, Windows 11, MacOS


### PR DESCRIPTION
Microsoft has released a functionality, which is very new and enables the developers to use port forwarding on their systems to expose locally hosted applications over the internet. This functionality aids developers to expose their systems directly on the internet without the need to host their applications on any server. The functionality is like Live Preview in the VSCode which allows the developers to host their websites locally but now with added functionality, they can forward the local ports over the internet. Thus, anyone on the internet can access the applications developed.

As per my research, the binary can be used to open up forwarded ports on the local system and then access the data over the internet via the generated dev tunnel URLs. 

Research can be found on the below link.

https://cydefops.com/vscode-data-exfiltration

The binary will be covered in the second part of the research which will be published soon, however same is achieved via devtunnels within the VScode which executes the same binary.