### PR TITLE
Create Appcert.yml

### DIFF
--- a/yml/OtherMSBinaries/Appcert.yml
+++ b/yml/OtherMSBinaries/Appcert.yml
@@ -11,12 +11,12 @@ Commands:
     Privileges: Administrator
     MitreID: T1127
     OperatingSystem: Windows
-  - Command: appcert.exe test -apptype desktop -setuppath c:\users\public\malicious.msi -setupcommandline /q -reportoutputpath c:\users\public\output.xml 
+  - Command: appcert.exe test -apptype desktop -setuppath c:\users\public\malicious.msi -setupcommandline /q -reportoutputpath c:\users\public\output.xml
     Description: Install an MSI file via an msiexec instance spawned via appcert.exe as parent process.
     Usecase: Execute custom made MSI file with malicious code
     Category: Execute
     Privileges: Administrator
-    MitreID: T1127
+    MitreID: T1218.007
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\App Certification Kit\appcert.exe

--- a/yml/OtherMSBinaries/Appcert.yml
+++ b/yml/OtherMSBinaries/Appcert.yml
@@ -1,19 +1,19 @@
 ---
 Name: AppCert.exe
 Description: Windows App Certification Kit command-line tool.
-Author: 'Avihay Eldad'
+Author: Avihay Eldad
 Created: 2024-03-06
 Commands:
-  - Command: appcert.exe test -apptype desktop -setuppath c:\windows\system32\notepad.exe -reportoutputpath c:\users\public\lala.xml
-    Description: Execute EXE file using Windows App Certification Kit command-line tool.
-    Usecase: Proxy execution of specified file with appcert.exe as a parent process.
+  - Command: appcert.exe test -apptype desktop -setuppath c:\windows\system32\notepad.exe -reportoutputpath c:\users\public\output.xml
+    Description: Execute an executable file via the Windows App Certification Kit command-line tool.
+    Usecase: Performs execution of specified file, can be used as a defense evasion
     Category: Execute
     Privileges: Administrator
     MitreID: T1127
     OperatingSystem: Windows
-  - Command: appcert.exe test -apptype desktop -setuppath c:\users\public\malicious.msi -reportoutputpath c:\users\public\lala.xml
-    Description: Execute MSI file using Windows App Certification Kit command-line tool.
-    Usecase: Proxy execution of specified file with appcert.exe as a parent process.
+  - Command: appcert.exe test -apptype desktop -setuppath c:\users\public\malicious.msi -setupcommandline /q -reportoutputpath c:\users\public\output.xml 
+    Description: Install an MSI file via an msiexec instance spawned via appcert.exe as parent process.
+    Usecase: Execute custom made MSI file with malicious code
     Category: Execute
     Privileges: Administrator
     MitreID: T1127

--- a/yml/OtherMSBinaries/Appcert.yml
+++ b/yml/OtherMSBinaries/Appcert.yml
@@ -20,12 +20,9 @@ Commands:
     OperatingSystem: Windows
 Full_Path:
   - Path: C:\Program Files (x86)\Windows Kits\10\App Certification Kit\appcert.exe
-Code_Sample:
-  - Code:
-Detection:
-  - Sigma:
+  - Path: C:\Program Files\Windows Kits\10\App Certification Kit\appcert.exe
 Resources:
-  - Link:
+  - Link: https://learn.microsoft.com/windows/win32/win_cert/using-the-windows-app-certification-kit
 Acknowledgement:
   - Person: Avihay Eldad
     Handle: '@AvihayEldad'

--- a/yml/OtherMSBinaries/Appcert.yml
+++ b/yml/OtherMSBinaries/Appcert.yml
@@ -1,0 +1,31 @@
+---
+Name: AppCert.exe
+Description: Windows App Certification Kit command-line tool.
+Author: 'Avihay Eldad'
+Created: 2024-03-06
+Commands:
+  - Command: appcert.exe test -apptype desktop -setuppath c:\windows\system32\notepad.exe -reportoutputpath c:\users\public\lala.xml
+    Description: Execute EXE file using Windows App Certification Kit command-line tool.
+    Usecase: Proxy execution of specified file with appcert.exe as a parent process.
+    Category: Execute
+    Privileges: Administrator
+    MitreID: T1127
+    OperatingSystem: Windows
+  - Command: appcert.exe test -apptype desktop -setuppath c:\users\public\malicious.msi -reportoutputpath c:\users\public\lala.xml
+    Description: Execute MSI file using Windows App Certification Kit command-line tool.
+    Usecase: Proxy execution of specified file with appcert.exe as a parent process.
+    Category: Execute
+    Privileges: Administrator
+    MitreID: T1127
+    OperatingSystem: Windows
+Full_Path:
+  - Path: C:\Program Files (x86)\Windows Kits\10\App Certification Kit\appcert.exe
+Code_Sample:
+  - Code:
+Detection:
+  - Sigma:
+Resources:
+  - Link:
+Acknowledgement:
+  - Person: Avihay Eldad
+    Handle: '@AvihayEldad'


### PR DESCRIPTION
AppCert.exe can be used to proxy execution of EXE/MSI files with appcert.exe as a parent process.

![appcert_exe](https://github.com/LOLBAS-Project/LOLBAS/assets/46644022/cdaf754b-08f4-4a16-ad69-e1e8e3a2fcbf)

![appcert_msi](https://github.com/LOLBAS-Project/LOLBAS/assets/46644022/9089bf08-3cc9-4914-86f8-7e744e82fc2d)

https://learn.microsoft.com/en-us/windows/win32/win_cert/using-the-windows-app-certification-kit