### PR TITLE
Add ECMangen.yml

### DIFF
--- a/yml/OtherMSBinaries/ECMangen.yml
+++ b/yml/OtherMSBinaries/ECMangen.yml
@@ -14,9 +14,9 @@ Commands:
     Tags:
       - Download: INetCache
 Full_Path:
-  - Path: C:\Program Files (x86)\Microsoft SDKs\Windows\{version}\Bin\ECMangen.exe
-  - Path: C:\Program Files (x86)\Microsoft SDKs\Windows\{version}\Bin\x64\ECMangen.exe
-  - Path: C:\Program Files\Microsoft\Exchange Server\{version}\Bin\ECMangen.exe
+  - Path: C:\Program Files (x86)\Microsoft SDKs\Windows\<version>\Bin\ECMangen.exe
+  - Path: C:\Program Files (x86)\Microsoft SDKs\Windows\<version>\Bin\x64\ECMangen.exe
+  - Path: C:\Program Files\Microsoft\Exchange Server\<version>\Bin\ECMangen.exe
   - Path: C:\Program Files\Microsoft\Exchange Server\Bin\ECMangen.exe
   - Path: C:\Program Files\Microsoft\Exchange Server\ClientAccess\Bin\ECMangen.exe
   - Path: C:\ExchangeServer\Bin\ECMangen.exe


### PR DESCRIPTION
Command-line tool for managing certificates in Microsoft Exchange Server (ECMangen.exe) can be used to download a remote payload and place it in INetCache folder.

![ECMangen](https://github.com/LOLBAS-Project/LOLBAS/assets/46644022/42eb6418-4475-4aa6-a115-06edaef58d0f)