### PR TITLE
Update Csc.yml

### DIFF
--- a/yml/OSBinaries/Csc.yml
+++ b/yml/OSBinaries/Csc.yml
@@ -4,15 +4,15 @@ Description: Binary file used by .NET Framework to compile C# code
 Author: 'Oddvar Moe'
 Created: 2018-05-25
 Commands:
-  - Command: csc.exe -out:My.exe File.cs
-    Description: Use CSC.EXE to compile .NET Framework C# code stored in File.cs and output the compiled version to My.exe.
+  - Command: csc.exe -out:Output.exe File.cs
+    Description: Use csc.exe to compile C# code, targeting the .NET Framework, stored in File.cs and output the compiled version to Output.exe.
     Usecase: Compile attacker code on system. Bypass defensive counter measures.
     Category: Compile
     Privileges: User
     MitreID: T1127
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
   - Command: csc -target:library File.cs
-    Description: Use CSC.EXE to compile C# code stored in File.cs and output the compiled version to a dll file.
+    Description: Use csc.exe to compile C# code, targeting the .NET Framework, stored in File.cs and output the compiled version to a DLL file.
     Usecase: Compile attacker code on system. Bypass defensive counter measures.
     Category: Compile
     Privileges: User
@@ -31,6 +31,3 @@ Detection:
   - IOC: Csc.exe should normally not run as System account unless it is used for development.
 Resources:
   - Link: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/
-Acknowledgement:
-  - Person:
-    Handle:

--- a/yml/OSBinaries/Csc.yml
+++ b/yml/OSBinaries/Csc.yml
@@ -1,11 +1,11 @@
 ---
 Name: Csc.exe
-Description: Binary file used by .NET to compile C# code
+Description: Binary file used by .NET Framework to compile C# code
 Author: 'Oddvar Moe'
 Created: 2018-05-25
 Commands:
   - Command: csc.exe -out:My.exe File.cs
-    Description: Use CSC.EXE to compile C# code stored in File.cs and output the compiled version to My.exe.
+    Description: Use CSC.EXE to compile .NET Framework C# code stored in File.cs and output the compiled version to My.exe.
     Usecase: Compile attacker code on system. Bypass defensive counter measures.
     Category: Compile
     Privileges: User
@@ -30,7 +30,7 @@ Detection:
   - Elastic: https://github.com/elastic/detection-rules/blob/82ec6ac1eeb62a1383792719a1943b551264ed16/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
   - IOC: Csc.exe should normally not run as System account unless it is used for development.
 Resources:
-  - Link: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/command-line-building-with-csc-exe
+  - Link: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/
 Acknowledgement:
   - Person:
     Handle:


### PR DESCRIPTION
.NET and .NET Framework are not interchangeable. `csc.exe` is only used to compile .NET Framework projects, not .NET. Also, the provided link returns a 404, I updated it.