### PR TITLE
Update Winget.yml

### DIFF
--- a/yml/OSBinaries/Winget.yml
+++ b/yml/OSBinaries/Winget.yml
@@ -5,18 +5,18 @@ Author: Paul Sanders
 Created: 2022-01-03
 Commands:
   - Command: winget.exe install --manifest manifest.yml
-    Description: 'Downloads a file from the web address specified in manifest.yml and executes it on the system. Local manifest setting must be enabled in winget for it to work: "winget settings --enable LocalManifestFiles"'
+    Description: 'Downloads a file from the web address specified in manifest.yml and executes it on the system. Local manifest setting must be enabled in winget for it to work: `winget settings --enable LocalManifestFiles`'
     Usecase: Download and execute an arbitrary file from the internet
     Category: Execute
     Privileges: Local Administrator - required to enable local manifest setting
     MitreID: T1105
     OperatingSystem: Windows 10, Windows 11
-  - Command: winget.exe install [ms store ID]
-    Description: 'Allows to download any MS Store program, using it's Store ID, even if MS Store itself is blocked on the machine. Has some potential if someone pushes malicious programs into the MS Store.'
-    Usecase: Download and install software from MS Store even if MS Store is blocked
-    Category: Execute
+  - Command: winget.exe install [Microsoft Store ID]
+    Description: Download and install any software from the Microsoft Store using its Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite.
+    Usecase: Download and install software from Microsoft Store, even if Microsoft Store App is blocked
+    Category: Download
     Privileges: User
-    MitreID: T1072
+    MitreID: T1105
     OperatingSystem: Windows 10, Windows 11
 Full_Path:
   - Path: C:\Users\user\AppData\Local\Microsoft\WindowsApps\winget.exe

--- a/yml/OSBinaries/Winget.yml
+++ b/yml/OSBinaries/Winget.yml
@@ -11,8 +11,8 @@ Commands:
     Privileges: Local Administrator - required to enable local manifest setting
     MitreID: T1105
     OperatingSystem: Windows 10, Windows 11
-  - Command: winget.exe install [Microsoft Store ID]
-    Description: Download and install any software from the Microsoft Store using its Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite.
+  - Command: winget.exe install --accept-package-agreements -s msstore [name or ID]
+    Description: Download and install any software from the Microsoft Store using its Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use "Sysinternals Suite" or `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite. 
     Usecase: Download and install software from Microsoft Store, even if Microsoft Store App is blocked
     Category: Download
     Privileges: User

--- a/yml/OSBinaries/Winget.yml
+++ b/yml/OSBinaries/Winget.yml
@@ -11,6 +11,13 @@ Commands:
     Privileges: Local Administrator - required to enable local manifest setting
     MitreID: T1105
     OperatingSystem: Windows 10, Windows 11
+  - Command: winget.exe install [ms store ID]
+    Description: 'Allows to download any MS Store program, using it's Store ID, even if MS Store itself is blocked on the machine. Has some potential if someone pushes malicious programs into the MS Store.'
+    Usecase: Download and install software from MS Store even if MS Store is blocked
+    Category: Execute
+    Privileges: User
+    MitreID: T1072
+    OperatingSystem: Windows 10, Windows 11
 Full_Path:
   - Path: C:\Users\user\AppData\Local\Microsoft\WindowsApps\winget.exe
 Code_Sample:
@@ -26,3 +33,4 @@ Resources:
 Acknowledgement:
   - Person: Paul
     Handle: '@saulpanders'
+  - Person: Konrad 'unrooted' Klawikowski

--- a/yml/OSBinaries/Winget.yml
+++ b/yml/OSBinaries/Winget.yml
@@ -12,7 +12,7 @@ Commands:
     MitreID: T1105
     OperatingSystem: Windows 10, Windows 11
   - Command: winget.exe install --accept-package-agreements -s msstore [name or ID]
-    Description: Download and install any software from the Microsoft Store using its Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use "Sysinternals Suite" or `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite. Note: a Microsoft account is required for this.
+    Description: 'Download and install any software from the Microsoft Store using its Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use "Sysinternals Suite" or `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite. Note: a Microsoft account is required for this.'
     Usecase: Download and install software from Microsoft Store, even if Microsoft Store App is blocked
     Category: Download
     Privileges: User

--- a/yml/OSBinaries/Winget.yml
+++ b/yml/OSBinaries/Winget.yml
@@ -12,7 +12,7 @@ Commands:
     MitreID: T1105
     OperatingSystem: Windows 10, Windows 11
   - Command: winget.exe install --accept-package-agreements -s msstore [name or ID]
-    Description: Download and install any software from the Microsoft Store using its Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use "Sysinternals Suite" or `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite. 
+    Description: Download and install any software from the Microsoft Store using its Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use "Sysinternals Suite" or `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite. Note: a Microsoft account is required for this.
     Usecase: Download and install software from Microsoft Store, even if Microsoft Store App is blocked
     Category: Download
     Privileges: User

--- a/yml/OSBinaries/Winget.yml
+++ b/yml/OSBinaries/Winget.yml
@@ -12,7 +12,7 @@ Commands:
     MitreID: T1105
     OperatingSystem: Windows 10, Windows 11
   - Command: winget.exe install --accept-package-agreements -s msstore [name or ID]
-    Description: 'Download and install any software from the Microsoft Store using its Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use "Sysinternals Suite" or `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite. Note: a Microsoft account is required for this.'
+    Description: 'Download and install any software from the Microsoft Store using its name or Store ID, even if the Microsoft Store App itself is blocked on the machine. For example, use "Sysinternals Suite" or `9p7knl5rwt25` for obtaining ProcDump, PsExec via the Sysinternals Suite. Note: a Microsoft account is required for this.'
     Usecase: Download and install software from Microsoft Store, even if Microsoft Store App is blocked
     Category: Download
     Privileges: User


### PR DESCRIPTION
Hi, I've spotted this only recently. 

Even tho MS Store is blocked on my machine: 
![signal-2024-07-12-234525_002](https://github.com/user-attachments/assets/5ef4bb80-20f7-4127-9eea-72fc6659e4b8)

I've been able to use winget to install a program with source from msstore, using it's store ID (compared both, the ID in winget is the same as the ID on the MS Store), as seen on the screenshots below

![signal-2024-07-12-234525_003](https://github.com/user-attachments/assets/b070ba73-271b-440e-8504-0419a4d89c69)

![signal-2024-07-12-234525_004](https://github.com/user-attachments/assets/0d3c820d-5e01-437a-973a-0cc17e385c63)
 
(Kali WSL only as an example ofc)

it's not a big thing, but interesting that it doesn't care that MS Store is blocked and still allows programs with source from the MS Store to be installed on the machine

I don't see a lot of potential in here, nowhere near what's been previously added to the winget description, but would be interesting in someone pushing malicious programs into the MS Store and then utilizing winget to get past MS Store being blocked on the machine

Also, I think that MitreID T1072 suits this the best, however, correct me if I'm wrong 