### PR TITLE
[Meta-improvement] URLs - add support for tilde character in Github action YAML

### DIFF
--- a/YML-Schema.yml
+++ b/YML-Schema.yml
@@ -92,19 +92,19 @@ mapping:
             type: str
           "Sigma":
             type: str
-            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
+            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
           "Analysis":
             type: str
-            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
+            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
           "Elastic":
             type: str
-            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
+            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
           "Splunk":
             type: str
-            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
+            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
           "BlockRule":
             type: str
-            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
+            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
   "Resources":
     type: seq
     required: false
@@ -113,7 +113,7 @@ mapping:
         mapping:
           "Link":
             type: str
-            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
+            pattern: '^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+#~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$'
   "Acknowledgement":
     type: seq
     required: false


### PR DESCRIPTION
I previously tried to submit a URL that used a tilde character [`~`], namely https://www.cs.toronto.edu/~simon/howto/win2kcommands.html , but [tests failed](https://github.com/LOLBAS-Project/LOLBAS/pull/389/commits/403faad919ddb871928791e2aaa38e88c21bc7a2) . Upon examination, I noticed that the Regex filters are not considering the case that a tilde may be in the URL.

For now, I bypassed this check by [applying URL-encode on top the of the problematic character](https://github.com/LOLBAS-Project/LOLBAS/pull/389/commits/fc5243e562e62eca72cc9e59a58eebbf6c930a52). This worked.

However, this PR aims to address this issue properly.

Tilde-containg URLs are somewhat common in the educational setting, e.g., universities. [See more](https://webmasters.stackexchange.com/q/42891)

This PR allow-lists the tilde, enabling the tilde-containing URLs to pass Github Action,