### PR TITLE
Odbcconf.yml - Corrected incorrect privileges

### DIFF
--- a/yml/OSBinaries/Odbcconf.yml
+++ b/yml/OSBinaries/Odbcconf.yml
@@ -28,7 +28,7 @@ Commands:
     Description: Load DLL specified in target .RSP file. See the Code Sample section for an example .RSP file.
     Usecase: Execute dll file using technique that can evade defensive counter measures
     Category: Execute
-    Privileges: User
+    Privileges: Administrator
     MitreID: T1218.008
     OperatingSystem: Windows vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
 Full_Path:


### PR DESCRIPTION
Small correction


There is an incorrect value for privileges listed despite it stating there is an admin requirement in the description for the command.