### PR TITLE
Add ComputerDefaults.yml

### DIFF
--- a/yml/OSBinaries/ComputerDefaults.yml
+++ b/yml/OSBinaries/ComputerDefaults.yml
@@ -1,0 +1,29 @@
+---
+Name: ComputerDefaults.exe
+Description: ComputerDefaults.exe is a Windows system utility for managing default applications for tasks like web browsing, emailing, and media playback.
+Aliases:  # Optional field if any common aliases exist of the binary with nearly the same functionality,
+  - Alias:  # but for example, is built for different architecture.
+Author: Eron Clarke
+Created: 2024-09-24 # YYYY-MM-DD (date the person created this file)
+Commands:
+  - Command: .\ComputerDefaults.exe
+    Description: Upon execution, ComputerDefaults.exe checks the registry value at HKEY_CURRENT_USER\Software\Classes\ms-settings\Shell\open\command, and if this key is created or modified by an attacker, it can force the binary to execute an arbitrary command.
+    Usecase: Used to execute a binary or script and bypass application whitelisting
+    Category: Execute
+    Privileges: User
+    MitreID: T1218
+    OperatingSystem: Windows 10, Windows 11
+    Tags:
+      - Key1: Execute # Optional field for one or more tags
+Full_Path:
+  - Path: C:\Windows\System32\ComputerDefaults.exe
+  - Path: C:\Windows\SysWOW64\ComputerDefaults.exe
+Detection:
+  - IOC: Event ID 10
+  - IOC: A binary or script spawned as a child process of ComputerDefaults.exe
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/proc_creation_win_uac_bypass_computerdefaults.yml
+Resources:
+  - Link: https://gist.github.com/havoc3-3/812547525107bd138a1a839118a3a44b
+Acknowledgement:
+  - Person: Eron Clarke
+    Handle: 

--- a/yml/OSBinaries/ComputerDefaults.yml
+++ b/yml/OSBinaries/ComputerDefaults.yml
@@ -1,26 +1,23 @@
 ---
 Name: ComputerDefaults.exe
 Description: ComputerDefaults.exe is a Windows system utility for managing default applications for tasks like web browsing, emailing, and media playback.
-Aliases:  # Optional field if any common aliases exist of the binary with nearly the same functionality,
-  - Alias:  # but for example, is built for different architecture.
 Author: Eron Clarke
-Created: 2024-09-24 # YYYY-MM-DD (date the person created this file)
+Created: 2024-09-24
 Commands:
-  - Command: .\ComputerDefaults.exe
-    Description: Upon execution, ComputerDefaults.exe checks the registry value at HKEY_CURRENT_USER\Software\Classes\ms-settings\Shell\open\command, and if this key is created or modified by an attacker, it can force the binary to execute an arbitrary command.
-    Usecase: Used to execute a binary or script and bypass application whitelisting
-    Category: Execute
+  - Command: ComputerDefaults.exe
+    Description: Upon execution, ComputerDefaults.exe checks two registry values at HKEY_CURRENT_USER\Software\Classes\ms-settings\Shell\open\command; if these are set by an attacker, the set command will be executed as a high-integrity process without a UAC prompt being displayed to the user. See 'resources' for which registry keys/values to set.
+    Usecase: Execute a binary or script as a high-integrity process without a UAC prompt.
+    Category: UAC bypass
     Privileges: User
-    MitreID: T1218
+    MitreID: T1548.002
     OperatingSystem: Windows 10, Windows 11
-    Tags:
-      - Key1: Execute # Optional field for one or more tags
 Full_Path:
   - Path: C:\Windows\System32\ComputerDefaults.exe
   - Path: C:\Windows\SysWOW64\ComputerDefaults.exe
 Detection:
   - IOC: Event ID 10
   - IOC: A binary or script spawned as a child process of ComputerDefaults.exe
+  - IOC: Changes to HKEY_CURRENT_USER\Software\Classes\ms-settings\Shell\open\command
   - Sigma: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/proc_creation_win_uac_bypass_computerdefaults.yml
 Resources:
   - Link: https://gist.github.com/havoc3-3/812547525107bd138a1a839118a3a44b

--- a/yml/OSBinaries/ComputerDefaults.yml
+++ b/yml/OSBinaries/ComputerDefaults.yml
@@ -7,7 +7,7 @@ Commands:
   - Command: ComputerDefaults.exe
     Description: Upon execution, ComputerDefaults.exe checks two registry values at HKEY_CURRENT_USER\Software\Classes\ms-settings\Shell\open\command; if these are set by an attacker, the set command will be executed as a high-integrity process without a UAC prompt being displayed to the user. See 'resources' for which registry keys/values to set.
     Usecase: Execute a binary or script as a high-integrity process without a UAC prompt.
-    Category: UAC bypass
+    Category: UAC Bypass
     Privileges: User
     MitreID: T1548.002
     OperatingSystem: Windows 10, Windows 11

--- a/yml/OSBinaries/ComputerDefaults.yml
+++ b/yml/OSBinaries/ComputerDefaults.yml
@@ -26,4 +26,3 @@ Resources:
   - Link: https://gist.github.com/havoc3-3/812547525107bd138a1a839118a3a44b
 Acknowledgement:
   - Person: Eron Clarke
-    Handle: 


### PR DESCRIPTION
ComputerDefaults.exe can be used to proxy the execution of unsigned binaries by editing/adding the target command to the HKEY_CURRENT_USER\Software\Classes\ms-settings\Shell\open\command key value. 

![ComputerDefaults_poc](https://github.com/user-attachments/assets/ecc7644e-32c3-458f-862d-9c6cc82615cf)
