### PR TITLE
wevtutil.exe deployment for Defense evasion

### DIFF
--- a/yml/OSBinaries/wevtutil.yaml
+++ b/yml/OSBinaries/wevtutil.yaml
@@ -1,0 +1,38 @@
+Name: wevtutil
+Description: This binary is created by windows to allow you to interact and preform actions(like stopping records or clearing) on logs within the windows local and remote host
+Author: Abdul Mhanni
+Created: 2025-03-25
+Commands:
+  - Command: WevtUtil.exe clear-log "log name"
+    Description: Clearing the specified log, note is case sensitive and must be in quotation marks. All logs present can be retrived via wevtutil.exe el
+    Usecase: You can use wevtutil to clear any log on a local or remote host(using /r). For remote host you can use NTLM for authentication as well as Username/Password
+    Category: Execute
+    Privileges: Local Administrator
+    MitreID: T1070
+    OperatingSystem: Windows vista and Up
+    Tags:
+      
+  - Command: wevtutil set-log "Microsoft-Windows-PowerShell/Operational" /e:false
+    Description: Setting the Microsoft-Windows-PowerShell/Operational log to false and thus stopping new events from being written to it
+    Usecase: When potentially trying to do a certain task or action, you can disable one or more logs, preform the action and then resume logging.
+    Allows for better stealth as opposed to complete clearing of all logs which may raise suspicion
+    Category: Execute
+    Privileges: Local Administrator
+    MitreID: T1070
+    OperatingSystem: Windows vista and Up
+Full_Path:
+  - Path: c:\windows\System32\wevtutil.exe
+Detection:
+  - IOC: Event ID 4688 where wevtutil cmd args includes set-log(sl) or clear-log(cl)
+  - IOC: wevtutil.exe spawned
+  - IOC: Event ID 1102 - Event Log Cleared in the Security logs
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/proc_creation_win_susp_eventlog_clear.yml
+  - Elastic: https://www.elastic.co/guide/en/security/current/clearing-windows-event-logs.html
+  - Splunk: https://lantern.splunk.com/Security/UCE/Guided_Insights/Threat_hunting/Detecting_a_ransomware_attack/Wevtutil.exe_abuse
+Resources:
+  - Link: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/wevtutil
+  - Link: https://ss64.com/nt/wevtutil.html
+Acknowledgement:
+  - Person: Abdul Mhanni
+    Handle: 'linkedin.com/in/abdulmhanni'
+  


### PR DESCRIPTION
wevtutil.exe deployment for log evasion
Wevtutil.exe is created by windows to be used by system administrator's and for mainly trouble shooting purposes; not for actors to abuse to hide their tracks or create visibility gaps. The binary really shines less when used to straight up clear logs, as it is useful to momentarily disable logs of interest to preform certain actions more stealthy and then resume logging as normal.
It is unlikely that defenders would notice a 2-3 minute gap in logging and thus can allow you crucial minutes to preform nosier/high risk activity while reducing risk of detection. Many red teamers and pentesters(at my workplace included) were not aware of the ability to pause logging and resume it with relative ease and expressed interest in having it handy. [Potentially others are in the same spot and would benefit from having it in the project!