### PR TITLE
add taskkill.exe to LOLBAS

### DIFF
--- a/yml/OSBinaries/Taskkill.yml
+++ b/yml/OSBinaries/Taskkill.yml
@@ -1,0 +1,18 @@
+name: Taskkill
+description: taskkill.exe is a native Windows binary that can terminate processes locally or remotely. It can be abused by attackers to kill security, monitoring, or IR tools, either locally or over the network using valid credentials.
+author: Mahdi Hamedani Nezhad
+date: 2025-05-03
+commands:
+  - command: taskkill /S 192.168.1.10 /U DOMAIN\AdminUser /P P@ssw0rd! /IM defender.exe /F
+    description: Remotely kill a process on another host using valid domain credentials
+  - command: taskkill /IM csagent.exe /F
+    description: Kill a local CrowdStrike sensor
+  - command: for /f %i in (targetlist.txt) do taskkill /IM %i /F
+    description: Loop through a file to kill listed processes
+  - command: taskkill /PID 1234 /F
+    description: Forcefully kill a process using its PID
+full_path:
+  - C:\Windows\System32\taskkill.exe
+code_sign:
+  - Microsoft Windows
+


### PR DESCRIPTION
Summary
This pull request proposes the inclusion of taskkill.exe as a new LOLBin under the OSBinaries category. Although taskkill.exe is a legitimate utility used to terminate processes, it contains unexpected and useful functionality for red teamers and adversaries, particularly in remote process manipulation and defense evasion scenarios.

Justification
The binary meets the LOLBAS criteria as follows:

It is a Microsoft-signed binary.

It is included by default in all supported versions of Windows (client and server).

It provides unexpected functionality, such as the ability to terminate processes on remote hosts without needing additional tooling.

It can be abused to kill defensive tools (AV, EDR, forensic processes), aiding in defense evasion.

It is useful for red teams, malware authors, and APT actors during lateral movement and post-exploitation activities.

Example Usage
Terminate a process on a remote system:

taskkill /s REMOTE_HOST /u DOMAIN\user /p password /im notepad.exe /f
Terminate a local security tool:

taskkill /im edragent.exe /f

Compatibility
The binary has been tested and is available on the following platforms:

Windows 10

Windows 11

Windows Server 2016

Windows Server 2019

Windows Server 2022

Path: C:\Windows\System32\taskkill.exe

Files Added
yml/OSBinaries/Taskkill.yml

References
https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill

Internal testing confirming remote process termination capabilities


