### PR TITLE
Add winrs.exe

### DIFF
--- a/yml/OSBinaries/Winrs.yml
+++ b/yml/OSBinaries/Winrs.yml
@@ -13,8 +13,7 @@ Commands:
     MitreID: T1218
     OperatingSystem: "Windows 10, Windows 11, Windows Server"
     Tags:
-      - Name: Execute
-        Value: CMD
+      - Execute: CMD
 
 Full_Path:
   - Path: C:\Windows\System32\Winrs.exe


### PR DESCRIPTION
Winrs is the binary used to execute commands on a remote host using WinRM. 
This binary can also be used to execute commands locally, as a child process of winrshost.exe.
