### PR TITLE
Wsl and bash

### DIFF
--- a/yml/OSBinaries/Bash.yml
+++ b/yml/OSBinaries/Bash.yml
@@ -61,6 +61,7 @@ Detection:
   - IOC: Child process from bash.exe
 Resources:
   - Link: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
+  - Link: TBA
 Acknowledgement:
   - Person: Alex Ionescu
     Handle: '@aionescu'

--- a/yml/OSBinaries/Bash.yml
+++ b/yml/OSBinaries/Bash.yml
@@ -55,13 +55,10 @@ Full_Path:
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_lolbin_bash.yml
-  - Sigma: TBA
-  - Sigma: TBA
-  - Sigma: TBA
   - IOC: Child process from bash.exe
 Resources:
   - Link: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
-  - Link: TBA
+  - Link: https://cardinalops.com/blog/bash-and-switch-hijacking-via-windows-subsystem-for-linux/
 Acknowledgement:
   - Person: Alex Ionescu
     Handle: '@aionescu'

--- a/yml/OSBinaries/Bash.yml
+++ b/yml/OSBinaries/Bash.yml
@@ -40,12 +40,24 @@ Commands:
     OperatingSystem: Windows 10
     Tags:
       - Execute: CMD
+  - Command: bash.exe
+    Description: When executed, bash.exe queries the registry value of 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\MSI\InstallLocation', which contains a folder path ('c:\program files\wsl' by default). If the value points to another folder containeing a file name wsl.exe, it will be executed instead of the legitimate wsl.exe in the program files folder.
+    Usecase: Execute a payload as a child process of bash.exe while masquerading as WSL.
+    Category: Execute
+    Privileges: User
+    MitreID: T1218, T1036.005
+    OperatingSystem: Windows 10
+    Tags:
+      - Execute: CMD
 Full_Path:
   - Path: C:\Windows\System32\bash.exe
   - Path: C:\Windows\SysWOW64\bash.exe
 Detection:
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - Sigma: https://github.com/SigmaHQ/sigma/blob/62d4fd26b05f4d81973e7c8e80d7c1a0c6a29d0e/rules/windows/process_creation/proc_creation_win_lolbin_bash.yml
+  - Sigma: TBA
+  - Sigma: TBA
+  - Sigma: TBA
   - IOC: Child process from bash.exe
 Resources:
   - Link: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
@@ -54,3 +66,4 @@ Acknowledgement:
     Handle: '@aionescu'
   - Person: Asif Matadar
     Handle: '@d1r4c'
+  - Person: Liran Ravich, CardinalOps

--- a/yml/OSBinaries/Bash.yml
+++ b/yml/OSBinaries/Bash.yml
@@ -46,7 +46,7 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218, T1036.005
-    OperatingSystem: Windows 10
+    OperatingSystem: Windows 10, Windows Server 2019, Windows 11
     Tags:
       - Execute: CMD
 Full_Path:

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -51,15 +51,12 @@ Full_Path:
   - Path: C:\Windows\System32\wsl.exe
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_wsl_lolbin_execution.yml
-  - Sigma: TBA
-  - Sigma: TBA
-  - Sigma: TBA
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: Child process from wsl.exe
 Resources:
   - Link: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - Link: https://twitter.com/nas_bench/status/1535431474429808642
-  - Link: TBA
+  - Link: https://cardinalops.com/blog/bash-and-switch-hijacking-via-windows-subsystem-for-linux/
 Acknowledgement:
   - Person: Alex Ionescu
     Handle: '@aionescu'

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -44,7 +44,7 @@ Commands:
     Category: Execute
     Privileges: User
     MitreID: T1218, T1036.005
-    OperatingSystem: Windows 10
+    OperatingSystem: Windows 10, Windows Server 2019, Windows 11
     Tags:
       - Execute: CMD
 Full_Path:

--- a/yml/OtherMSBinaries/Wsl.yml
+++ b/yml/OtherMSBinaries/Wsl.yml
@@ -38,15 +38,28 @@ Commands:
     Privileges: User
     MitreID: T1105
     OperatingSystem: Windows 10, Windows Server 2019, Windows 11
+  - Command: wsl.exe
+    Description: When executed, wsl.exe queries the registry value of 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\MSI\InstallLocation', which contains a folder path ('c:\program files\wsl' by default). If the value points to another folder containeing a file name wsl.exe, it will be executed instead of the legitimate wsl.exe in the program files folder.
+    Usecase: Execute a payload as a child process of bash.exe while masquerading as WSL.
+    Category: Execute
+    Privileges: User
+    MitreID: T1218, T1036.005
+    OperatingSystem: Windows 10
+    Tags:
+      - Execute: CMD
 Full_Path:
   - Path: C:\Windows\System32\wsl.exe
 Detection:
   - Sigma: https://github.com/SigmaHQ/sigma/blob/683b63f8184b93c9564c4310d10c571cbe367e1e/rules/windows/process_creation/proc_creation_win_wsl_lolbin_execution.yml
+  - Sigma: TBA
+  - Sigma: TBA
+  - Sigma: TBA
   - BlockRule: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - IOC: Child process from wsl.exe
 Resources:
   - Link: https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules
   - Link: https://twitter.com/nas_bench/status/1535431474429808642
+  - Link: TBA
 Acknowledgement:
   - Person: Alex Ionescu
     Handle: '@aionescu'
@@ -57,3 +70,4 @@ Acknowledgement:
   - Person: Nasreddine Bencherchali
     Handle: '@nas_bench'
   - Person: Konrad 'unrooted' Klawikowski
+  - Person: Liran Ravich, CardinalOps


### PR DESCRIPTION
When bash.exe or wsl.exe are executed, they both act in the same way:

Query the reg key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss\MSI\InstallLocation' for the WSL folder path ('c:\program files\wsl' by default). 
Look for wsl.exe inside the path sacrificed in the reg key and open it.

The wsl.exe binary in program files can be replaced or the reg key can be edited to execute a malicious payload instead of the legitimate wsl.exe.

The full breakdown can be found here:
https://cardinalops.com/blog/bash-and-switch-hijacking-via-windows-subsystem-for-linux/