### PR TITLE
Added Applaunch.yml

### DIFF
--- a/yml/OSBinaries/Applaunch.yml
+++ b/yml/OSBinaries/Applaunch.yml
@@ -1,0 +1,35 @@
+---
+Name: Applaunch.exe
+Description: ClickOnce partial-trust application launcher used by .NET. Can execute self-signed or untrusted ClickOnce applications without SmartScreen or standard AppLocker enforcement.
+Author: Nathan Sawyer
+Created: 2025-11-26
+Commands:
+  - Command: >
+      "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Applaunch.exe"
+      /activate "{APPLICATION_URL}#{APPLICATION_METADATA}"
+    Description: Launches a ClickOnce application via Applaunch.exe. Bypasses SmartScreen and default AppLocker rules when the application is published as partial trust.
+    Usecase: Execute ClickOnce applications in environments where dfsvc.exe would normally enforce full-trust and SmartScreen checks. Can be abused as an AWL bypass in rare configurations.
+    Category: AWL Bypass
+    Privileges: User
+    MitreID: T1127.002
+    OperatingSystem: Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10, Windows 11
+    Tags:
+      - Execute: ClickOnce
+      - Execute: Local
+      - Execute: InstalledApplication
+
+Full_Path:
+  - Path: C:\Windows\Microsoft.NET\Framework\v2.0.50727\Applaunch.exe
+  - Path: C:\Windows\Microsoft.NET\Framework64\v2.0.50727\Applaunch.exe
+  - Path: C:\Windows\Microsoft.NET\Framework\v4.0.30319\Applaunch.exe
+  - Path: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Applaunch.exe
+
+Detection:
+  - IOC: Applaunch.exe rarely executes unless any ClickOnce partial trusted apps are used. Any use or invocation outside dfsvc.exe with `/activate` should be considered suspicious.
+
+Resources:
+  - Link: https://learn.microsoft.com/en-us/visualstudio/deployment/clickonce-security-and-deployment
+  - Link: https://web.archive.org/web/20060913192623/http://blogs.msdn.com/shawnfa/archive/2005/11/30/498610.aspx
+
+Acknowledgement:
+  - Person: Nathan Sawyer


### PR DESCRIPTION
Applaunch can be used to launch ClickOnce applications published as partial trust applications. This is an AWL bypass that also bypasses smartscreen, as the application runs under Applaunch. 

Read more here: https://nathan2.com/posts/clicktools/