### PR TITLE
Added UevAppMonitor.yml

### DIFF
--- a/yml/OSBinaries/UevAppMonitor.yml
+++ b/yml/OSBinaries/UevAppMonitor.yml
@@ -9,7 +9,9 @@ Commands:
     Usecase: Snapshoting of Active Directory NTDS.dit database
     Category: Execute
     Privileges: User
-    MitreID: T1574.001, T1562.002
+    MitreID: 
+      - T1574.001
+      - T1562.002
     OperatingSystem: Windows 11, Windows 10, Windows Server
 Full_Path:
   - Path: C:\Windows\System32\UevAppMonitor.exe
@@ -19,3 +21,4 @@ Detection:
   - IOC: UevAppMonitor.exe executed by unusual parent process (commonly spawned by `svchost.exe -k netsvcs -p -s Schedule`)
 Resources:
   - Link: https://www.welivesecurity.com/en/eset-research/longnosedgoblin-tries-sniff-out-governmental-affairs-southeast-asia-japan/
+  - Link: https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/etwenable-element

--- a/yml/OSBinaries/UevAppMonitor.yml
+++ b/yml/OSBinaries/UevAppMonitor.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Snapshoting of Active Directory NTDS.dit database
     Category: Execute
     Privileges: User
-    MitreID: 
+    MitreID:
       - T1574.001
       - T1562.002
     OperatingSystem: Windows 11, Windows 10, Windows Server

--- a/yml/OSBinaries/UevAppMonitor.yml
+++ b/yml/OSBinaries/UevAppMonitor.yml
@@ -1,0 +1,21 @@
+---
+Name: UevAppMonitor.exe
+Description: Microsoft User Experience Virtualization (UE-V) App Monitor
+Author: Liran Ravich
+Created: 2026-01-05
+Commands:
+  - Command: UevAppMonitor.exe
+    Description: By using a custom config file (UevAppMonitor.exe.config), a malicious DLL can be loaded and the `<etwEnable>` flag can be set to false to prevent auditing.
+    Usecase: Snapshoting of Active Directory NTDS.dit database
+    Category: Execute
+    Privileges: User
+    MitreID: T1574.001, T1562.002
+    OperatingSystem: Windows 11, Windows 10, Windows Server
+Full_Path:
+  - Path: C:\Windows\System32\UevAppMonitor.exe
+Detection:
+  - IOC: Unusual modification to UevAppMonitor.exe.config
+  - IOC: UevAppMonitor.exe executed from unusual path
+  - IOC: UevAppMonitor.exe executed by unusual parent process (commonly spawned by `svchost.exe -k netsvcs -p -s Schedule`)
+Resources:
+  - Link: https://www.welivesecurity.com/en/eset-research/longnosedgoblin-tries-sniff-out-governmental-affairs-southeast-asia-japan/

--- a/yml/OSBinaries/UevAppMonitor.yml
+++ b/yml/OSBinaries/UevAppMonitor.yml
@@ -5,11 +5,18 @@ Author: Liran Ravich
 Created: 2026-01-05
 Commands:
   - Command: UevAppMonitor.exe
-    Description: By using a custom config file (UevAppMonitor.exe.config), a malicious DLL can be loaded and the `<etwEnable>` flag can be set to false to prevent auditing.
-    Usecase: Snapshoting of Active Directory NTDS.dit database
+    Description: By using a custom config file (UevAppMonitor.exe.config), a malicious DLL can be loaded
+    Usecase: Execute a malicious DLL
     Category: Execute
     Privileges: User
-    MitreID: T1574.001, T1562.002
+    MitreID: T1574.001
+    OperatingSystem: Windows 11, Windows 10, Windows Server
+  - Command: UevAppMonitor.exe
+    Description: The `<etwEnable>` flag can be set to false to prevent auditing
+    Usecase: Preventing event tracing when executing the process
+    Category: Execute
+    Privileges: User
+    MitreID: T1562.002
     OperatingSystem: Windows 11, Windows 10, Windows Server
 Full_Path:
   - Path: C:\Windows\System32\UevAppMonitor.exe

--- a/yml/OSBinaries/UevAppMonitor.yml
+++ b/yml/OSBinaries/UevAppMonitor.yml
@@ -9,7 +9,7 @@ Commands:
     Usecase: Snapshoting of Active Directory NTDS.dit database
     Category: Execute
     Privileges: User
-    MitreID: [T1574.001, T1562.002]
+    MitreID: T1574.001, T1562.002
     OperatingSystem: Windows 11, Windows 10, Windows Server
 Full_Path:
   - Path: C:\Windows\System32\UevAppMonitor.exe

--- a/yml/OSBinaries/UevAppMonitor.yml
+++ b/yml/OSBinaries/UevAppMonitor.yml
@@ -9,9 +9,7 @@ Commands:
     Usecase: Snapshoting of Active Directory NTDS.dit database
     Category: Execute
     Privileges: User
-    MitreID:
-      - T1574.001
-      - T1562.002
+    MitreID: [T1574.001, T1562.002]
     OperatingSystem: Windows 11, Windows 10, Windows Server
 Full_Path:
   - Path: C:\Windows\System32\UevAppMonitor.exe


### PR DESCRIPTION
UevAppMonitor can be used to load a malicious DLL by running it from a custom path (copied from System32) and using a custom config file (UevAppMonitor.exe.config).

Setting the "\<etwEnable\>" flag as false will tamper with the auditing of the events.