### PR TITLE
Windows Sandbox abuse via wsb.exe

### DIFF
--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -66,4 +66,3 @@ Resources:
 
 Acknowledgement:
   - Person: Konrad 'unrooted' Klawikowski
-  

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -18,7 +18,7 @@ Commands:
 
   - Command: |
         wsb start --config "<Configuration><MappedFolders><MappedFolder><HostFolder>{PATH_ABSOLUTE:folder}</HostFolder><ReadOnly>false</ReadOnly></MappedFolder></MappedFolders></Configuration>"
-        wsb exec -r System --id YOUR_ID -c "cmd.exe /c copy C:\users\WDAGUtilityAccount\Desktop\Temp\{PATH} {PATH}" 
+        wsb exec -r System --id YOUR_ID -c "cmd.exe /c copy C:\users\WDAGUtilityAccount\Desktop\Temp\{PATH} {PATH}"
     Description: "Allows the specified folder to be accessible from within the Windows Sandbox, mounted at `C:\users\WDAGUtilityAccount\Desktop` with the same folder name as the source folder. This allows, for example, for copying payloads from the host system into the sandbox, copying payloads from the sandbox back to the host system, or for accessing arbitrary host system files by the sandbox."
     Usecase: Fileless execution of arbitrary commands in an EDR-free environment, with access to files on the host system, while the host-side process tree is masked by the Sandbox client binaries.
     Category: Execute
@@ -31,7 +31,7 @@ Commands:
   - Command: |
       wsb start
       wsb share --id YOUR_ID -f {PATH_ABSOLUTE:folder} -s c:\SOME_FOLDER --allow-write
-      wsb exec -r System --id YOUR_ID -c "cmd.exe /c copy {PATH_ABSOLUTE} c:\SOME_FOLDER"       
+      wsb exec -r System --id YOUR_ID -c "cmd.exe /c copy {PATH_ABSOLUTE} c:\SOME_FOLDER"
     Description: 'Allows the specified folder to be accessible from within the Windows Sandbox, mounted at `c:\SOME_FOLDER`. This allows, for example, for copying payloads from the host system into the sandbox, copying payloads from the sandbox back to the host system (seen here), or for accessing arbitrary host system files by the sandbox.'
     Usecase: Fileless execution of arbitrary commands in an EDR-free environment, with access to files on the host system, while the host-side process tree is masked by the Sandbox client binaries.
     Category: Execute

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -57,6 +57,8 @@ Detection:
   - IOC: Microsoft-Windows-Sandbox-Client-Diagnostics/Admin event log entries for Sandbox lifecycle events correlated with wsb.exe invocations
 
 Resources:
+  - Link: https://web.archive.org/web/20250116184008/http://blog.syscall.party/2020/12/02/weaponizing-windows-sandbox.html
+  - Link: https://github.com/LloydLabs/wsb-detect
   - Link: https://learn.microsoft.com/windows/security/application-security/application-isolation/windows-sandbox/windows-sandbox-cli
   - Link: https://learn.microsoft.com/windows/security/application-security/application-isolation/windows-sandbox/windows-sandbox-versions
   - Link: https://github.com/secdev02/SandBoxShenanigans

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -64,4 +64,4 @@ Resources:
 Acknowledgement:
   - Person: Konrad 'unrooted' Klawikowski
   - Person: Lloyd Davies
-    Twitter: '@LloydLabs'
+    Handle: '@LloydLabs'

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -1,20 +1,18 @@
 ---
 Name: wsb.exe
-Description: Windows Sandbox command-line interface. Creates, lists, controls, and executes commands inside Windows Sandbox sessions from the host CLI. Available on Windows 11 24H2 and later after the Windows Sandbox app auto-upgrades itself via Microsoft Store update infrastructure - triggered on first launch once the Windows Sandbox optional feature is enabled. There is no separate Store catalog entry to search for; the upgrade is delivered in place.
+Description: Windows Sandbox command-line interface. Creates, lists, controls, and executes commands inside Windows Sandbox sessions from the host CLI.
 Author: Konrad 'unrooted' Klawikowski
 Created: 2026-05-28
 Commands:
-  - Command: wsb start --config "<Configuration><LogonCommand><Command>cmd.exe /c {payload}</Command></LogonCommand></Configuration>"
-    Description: 'Launches a Windows Sandbox from an inline XML configuration with an embedded `<LogonCommand>`, leaving no .wsb file on disk - the entire configuration is passed as a single command-line argument. Note: `<LogonCommand>` only fires once WDAGUtilityAccount actually logs in, which only happens after an RDP session is established via `wsb connect`, so this pattern opens a visible Sandbox window. For headless execution use `wsb exec -r System` instead. Inside the sandbox Windows Defender is disabled by default; from the host the sandbox is a Hyper-V VM, so the in-sandbox payload runs in a separate kernel and is invisible to host ETW / Sysmon entirely.'
-    Usecase: Fileless execution of arbitrary commands in a Defender-free environment whose host-side process tree is masked by the Sandbox client binaries
+  - Command: wsb start --config "<Configuration><LogonCommand><Command>{CMD}</Command></LogonCommand></Configuration>"
+    Description: 'Executes the given command in a Windows Sandbox from an inline XML configuration with an embedded `<LogonCommand>`, leaving no `.wsb` file on disk. Note: `<LogonCommand>` only fires once `WDAGUtilityAccount` actually logs in, which only happens after an RDP session is established via `wsb connect`, so this pattern opens a visible Sandbox window.
+    Usecase: Fileless execution of arbitrary commands in an EDR-free environment whose host-side process tree is masked by the Sandbox client binaries.
     Category: Execute
     Privileges: User
     MitreID: T1564.006
     OperatingSystem: Windows 11 24H2 and later
     Tags:
       - Execute: CMD
-      - Execute: EXE
-      - Execute: PowerShell
 
   - Command: wsb start --config "<Configuration><MappedFolders><MappedFolder><HostFolder>{HOST_PATH}</HostFolder><ReadOnly>false</ReadOnly></MappedFolder></MappedFolders><LogonCommand><Command>cmd.exe /c copy C:\users\WDAGUtilityAccount\Desktop\{folder}\{payload} {HOST_PATH}</Command></LogonCommand></Configuration>"
     Description: 'Adds an arbitrary read-write host-folder mapping to the inline XML, then uses the LogonCommand to drop a payload from inside the sandbox back onto that host path. Same logon-trigger caveat as the previous entry: `wsb connect` (visible window) is required to fire the LogonCommand. The resulting host-side file-creation event is attributed to the Hyper-V worker (vmwp.exe) - not to wsb.exe or the calling binary - so EDR rules keyed on the writing process miss the cross-boundary write entirely.'

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -66,3 +66,4 @@ Resources:
 
 Acknowledgement:
   - Person: Konrad 'unrooted' Klawikowski
+  

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -1,0 +1,68 @@
+---
+Name: wsb.exe
+Description: Windows Sandbox command-line interface. Creates, lists, controls, and executes commands inside Windows Sandbox sessions from the host CLI. Available on Windows 11 24H2 and later after the Windows Sandbox app auto-upgrades itself via Microsoft Store update infrastructure - triggered on first launch once the Windows Sandbox optional feature is enabled. There is no separate Store catalog entry to search for; the upgrade is delivered in place.
+Author: Konrad 'unrooted' Klawikowski
+Created: 2026-05-30
+Commands:
+  - Command: wsb start --config "<Configuration><LogonCommand><Command>cmd.exe /c {payload}</Command></LogonCommand></Configuration>"
+    Description: 'Launches a Windows Sandbox from an inline XML configuration with an embedded <LogonCommand>, leaving no .wsb file on disk - the entire configuration is passed as a single command-line argument. Note: <LogonCommand> only fires once WDAGUtilityAccount actually logs in, which only happens after an RDP session is established via `wsb connect`, so this pattern opens a visible Sandbox window. For headless execution use `wsb exec -r System` instead. Inside the sandbox Windows Defender is disabled by default; from the host the sandbox is a Hyper-V VM, so the in-sandbox payload runs in a separate kernel and is invisible to host ETW / Sysmon entirely.'
+    Usecase: Fileless execution of arbitrary commands in a Defender-free environment whose host-side process tree is masked by the Sandbox client binaries
+    Category: Execute
+    Privileges: User
+    MitreID: T1564.006
+    OperatingSystem: Windows 11 24H2 and later
+    Tags:
+      - Execute: CMD
+      - Execute: EXE
+      - Execute: PowerShell
+
+  - Command: wsb start --config "<Configuration><MappedFolders><MappedFolder><HostFolder>{HOST_PATH}</HostFolder><ReadOnly>false</ReadOnly></MappedFolder></MappedFolders><LogonCommand><Command>cmd.exe /c copy C:\users\WDAGUtilityAccount\Desktop\{folder}\{payload} {HOST_PATH}</Command></LogonCommand></Configuration>"
+    Description: 'Adds an arbitrary read-write host-folder mapping to the inline XML, then uses the LogonCommand to drop a payload from inside the sandbox back onto that host path. Same logon-trigger caveat as the previous entry: `wsb connect` (visible window) is required to fire the LogonCommand. The resulting host-side file-creation event is attributed to the Hyper-V worker (vmwp.exe) - not to wsb.exe or the calling binary - so EDR rules keyed on the writing process miss the cross-boundary write entirely.'
+    Usecase: Drop a payload to an arbitrary host filesystem location with the file-creation event's parent process chain obscured behind WindowsSandbox* binaries
+    Category: Execute
+    Privileges: User
+    MitreID: T1564.006
+    OperatingSystem: Windows 11 24H2 and later
+
+  - Command: wsb exec --id {sandbox_id} -c {payload.exe} -r System
+    Description: 'Executes a command inside an already-running Windows Sandbox in the SYSTEM context. Unlike -r ExistingLogin, -r System does NOT require an active user session, so no `wsb connect` is needed - this is the truly headless variant of the abuse pattern. Pairing this with a prior `wsb start` (without a LogonCommand) splits the CLI-argument surface across two distinct wsb.exe invocations, so detection rules that look for `--config` with embedded `<LogonCommand>` miss the combined pattern; correlation across calls (joined on sandbox-id GUID) is required.'
+    Usecase: Execute SYSTEM-context commands inside a sandbox that is already running, separating environment setup from payload delivery
+    Category: Execute
+    Privileges: User
+    MitreID: T1218
+    OperatingSystem: Windows 11 24H2 and later
+
+  - Command: wsb share --id {sandbox_id} -f {HOST_PATH} -s C:\mount --allow-write
+    Description: 'Shares a host folder into a running Windows Sandbox at runtime, with --allow-write granting sandbox-to-host writes. Before the wsb.exe CLI shipped in 24H2, mapped folders could only be declared statically in the .wsb at boot time; this subcommand lets a process that has already started a sandbox dynamically grant read-write access to additional host paths post-boot, without restarting or writing a configuration file. Detection rules that scan `wsb start` configs for read-write MappedFolder blocks miss this entirely.'
+    Usecase: Dynamically extend a running sandbox's read-write host filesystem access mid-session, post-boot
+    Category: Copy
+    Privileges: User
+    MitreID: T1105
+    OperatingSystem: Windows 11 24H2 and later
+
+Full_Path:
+  - Path: C:\Users\{user}\AppData\Local\Microsoft\WindowsApps\wsb.exe
+  - Path: C:\Program Files\WindowsApps\Microsoft.WindowsSandbox_*\wsb.exe
+
+Code_Sample:
+  - Code: https://gist.github.com/unrooted/c02f398c88205a437ad2fb592b61efff
+
+Detection:
+  - IOC: wsb.exe command line containing --config with an embedded <LogonCommand> XML element
+  - IOC: wsb.exe command line invoking the share subcommand with --allow-write
+  - IOC: wsb.exe command line invoking the exec subcommand with -r System
+  - IOC: Correlated pair - wsb.exe start followed by wsb.exe exec/share/connect against the same sandbox ID within a short window
+  - IOC: WindowsSandboxServer.exe spawns whenever a Sandbox session starts, regardless of whether anyone connects. Lives under %ProgramFiles%\WindowsApps\MicrosoftWindows.WindowsSandbox_*\.
+  - IOC: WindowsSandboxRemoteSession.exe spawns ONLY when an RDP connection to the Sandbox is established - opening a .wsb file directly auto-connects (so both processes appear), but `wsb start` alone does NOT spawn it. Its absence while WindowsSandboxServer.exe is alive means no user has connected.
+  - IOC (highest-signal for headless abuse) - WindowsSandboxServer.exe present WITHOUT WindowsSandboxRemoteSession.exe indicates a Sandbox VM is running with no interactive session. Legitimate usage almost always involves an RDP connection (because users want to use the Sandbox); a server-without-remote-session state is consistent with the `wsb exec -r System` headless attack primitive.
+  - IOC: vmwp.exe and vmmemWindowsSandbox spawned alongside wsb.exe activity indicate the Sandbox VM is up (vmwp is the Hyper-V worker hosting the Sandbox VM)
+  - IOC: Host-side file-creation events on paths corresponding to a mapped folder, attributed to vmwp.exe (Hyper-V worker), with timestamps inside the lifetime of an active Sandbox session - empirically verified on Windows 11 24H2 via Process Monitor; this is how a sandbox-to-host cross-boundary write surfaces from host telemetry
+  - IOC: Microsoft-Windows-Sandbox-Client-Diagnostics/Admin event log entries for Sandbox lifecycle events correlated with wsb.exe invocations
+
+Resources:
+  - Link: https://learn.microsoft.com/windows/security/application-security/application-isolation/windows-sandbox/windows-sandbox-cli
+  - Link: https://learn.microsoft.com/windows/security/application-security/application-isolation/windows-sandbox/windows-sandbox-versions
+  - Link: https://github.com/secdev02/SandBoxShenanigans
+
+Acknowledgement:
+  - Person: Konrad 'unrooted' Klawikowski

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -38,6 +38,8 @@ Commands:
     Privileges: User
     MitreID: T1564.006
     OperatingSystem: Windows 11 24H2 and later
+    Tags:
+      - Execute: CMD    
 
 Full_Path:
   - Path: C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\wsb.exe

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -19,7 +19,7 @@ Commands:
   - Command: |
         wsb start --config "<Configuration><MappedFolders><MappedFolder><HostFolder>{PATH_ABSOLUTE:folder}</HostFolder><ReadOnly>false</ReadOnly></MappedFolder></MappedFolders></Configuration>"
         wsb exec -r System --id YOUR_ID -c "cmd.exe /c copy C:\users\WDAGUtilityAccount\Desktop\Temp\{PATH} {PATH}"
-    Description: "Allows the specified folder to be accessible from within the Windows Sandbox, mounted at `C:\users\WDAGUtilityAccount\Desktop` with the same folder name as the source folder. This allows, for example, for copying payloads from the host system into the sandbox, copying payloads from the sandbox back to the host system, or for accessing arbitrary host system files by the sandbox."
+    Description: 'Allows the specified folder to be accessible from within the Windows Sandbox, mounted at `C:\users\WDAGUtilityAccount\Desktop` with the same folder name as the source folder. This allows, for example, for copying payloads from the host system into the sandbox, copying payloads from the sandbox back to the host system, or for accessing arbitrary host system files by the sandbox.'
     Usecase: Fileless execution of arbitrary commands in an EDR-free environment, with access to files on the host system, while the host-side process tree is masked by the Sandbox client binaries.
     Category: Execute
     Privileges: User

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -39,7 +39,7 @@ Commands:
     MitreID: T1564.006
     OperatingSystem: Windows 11 24H2 and later
     Tags:
-      - Execute: CMD    
+      - Execute: CMD
 
 Full_Path:
   - Path: C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\wsb.exe

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -2,10 +2,10 @@
 Name: wsb.exe
 Description: Windows Sandbox command-line interface. Creates, lists, controls, and executes commands inside Windows Sandbox sessions from the host CLI. Available on Windows 11 24H2 and later after the Windows Sandbox app auto-upgrades itself via Microsoft Store update infrastructure - triggered on first launch once the Windows Sandbox optional feature is enabled. There is no separate Store catalog entry to search for; the upgrade is delivered in place.
 Author: Konrad 'unrooted' Klawikowski
-Created: 2026-05-30
+Created: 2026-05-28
 Commands:
   - Command: wsb start --config "<Configuration><LogonCommand><Command>cmd.exe /c {payload}</Command></LogonCommand></Configuration>"
-    Description: 'Launches a Windows Sandbox from an inline XML configuration with an embedded <LogonCommand>, leaving no .wsb file on disk - the entire configuration is passed as a single command-line argument. Note: <LogonCommand> only fires once WDAGUtilityAccount actually logs in, which only happens after an RDP session is established via `wsb connect`, so this pattern opens a visible Sandbox window. For headless execution use `wsb exec -r System` instead. Inside the sandbox Windows Defender is disabled by default; from the host the sandbox is a Hyper-V VM, so the in-sandbox payload runs in a separate kernel and is invisible to host ETW / Sysmon entirely.'
+    Description: 'Launches a Windows Sandbox from an inline XML configuration with an embedded `<LogonCommand>`, leaving no .wsb file on disk - the entire configuration is passed as a single command-line argument. Note: `<LogonCommand>` only fires once WDAGUtilityAccount actually logs in, which only happens after an RDP session is established via `wsb connect`, so this pattern opens a visible Sandbox window. For headless execution use `wsb exec -r System` instead. Inside the sandbox Windows Defender is disabled by default; from the host the sandbox is a Hyper-V VM, so the in-sandbox payload runs in a separate kernel and is invisible to host ETW / Sysmon entirely.'
     Usecase: Fileless execution of arbitrary commands in a Defender-free environment whose host-side process tree is masked by the Sandbox client binaries
     Category: Execute
     Privileges: User
@@ -41,8 +41,7 @@ Commands:
     OperatingSystem: Windows 11 24H2 and later
 
 Full_Path:
-  - Path: C:\Users\{user}\AppData\Local\Microsoft\WindowsApps\wsb.exe
-  - Path: C:\Program Files\WindowsApps\Microsoft.WindowsSandbox_*\wsb.exe
+  - Path: C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\wsb.exe
 
 Code_Sample:
   - Code: https://gist.github.com/unrooted/c02f398c88205a437ad2fb592b61efff
@@ -54,7 +53,7 @@ Detection:
   - IOC: Correlated pair - wsb.exe start followed by wsb.exe exec/share/connect against the same sandbox ID within a short window
   - IOC: WindowsSandboxServer.exe spawns whenever a Sandbox session starts, regardless of whether anyone connects. Lives under %ProgramFiles%\WindowsApps\MicrosoftWindows.WindowsSandbox_*\.
   - IOC: WindowsSandboxRemoteSession.exe spawns ONLY when an RDP connection to the Sandbox is established - opening a .wsb file directly auto-connects (so both processes appear), but `wsb start` alone does NOT spawn it. Its absence while WindowsSandboxServer.exe is alive means no user has connected.
-  - IOC (highest-signal for headless abuse) - WindowsSandboxServer.exe present WITHOUT WindowsSandboxRemoteSession.exe indicates a Sandbox VM is running with no interactive session. Legitimate usage almost always involves an RDP connection (because users want to use the Sandbox); a server-without-remote-session state is consistent with the `wsb exec -r System` headless attack primitive.
+  - IOC: (highest-signal for headless abuse) WindowsSandboxServer.exe present WITHOUT WindowsSandboxRemoteSession.exe indicates a Sandbox VM is running with no interactive session. Legitimate usage almost always involves an RDP connection (because users want to use the Sandbox); a server-without-remote-session state is consistent with the `wsb exec -r System` headless attack primitive.
   - IOC: vmwp.exe and vmmemWindowsSandbox spawned alongside wsb.exe activity indicate the Sandbox VM is up (vmwp is the Hyper-V worker hosting the Sandbox VM)
   - IOC: Host-side file-creation events on paths corresponding to a mapped folder, attributed to vmwp.exe (Hyper-V worker), with timestamps inside the lifetime of an active Sandbox session - empirically verified on Windows 11 24H2 via Process Monitor; this is how a sandbox-to-host cross-boundary write surfaces from host telemetry
   - IOC: Microsoft-Windows-Sandbox-Client-Diagnostics/Admin event log entries for Sandbox lifecycle events correlated with wsb.exe invocations

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -5,7 +5,7 @@ Author: Konrad 'unrooted' Klawikowski
 Created: 2026-05-28
 Commands:
   - Command: wsb start --config "<Configuration><LogonCommand><Command>{CMD}</Command></LogonCommand></Configuration>"
-    Description: 'Executes the given command in a Windows Sandbox from an inline XML configuration with an embedded `<LogonCommand>`, leaving no `.wsb` file on disk. Note: `<LogonCommand>` only fires once `WDAGUtilityAccount` actually logs in, which only happens after an RDP session is established via `wsb connect`, so this pattern opens a visible Sandbox window.
+    Description: 'Executes the given command in a Windows Sandbox from an inline XML configuration with an embedded `<LogonCommand>`, leaving no `.wsb` file on disk. Note: `<LogonCommand>` only fires once `WDAGUtilityAccount` actually logs in, which only happens after an RDP session is established via `wsb connect`, so this pattern opens a visible Sandbox window.'
     Usecase: Fileless execution of arbitrary commands in an EDR-free environment whose host-side process tree is masked by the Sandbox client binaries.
     Category: Execute
     Privileges: User

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -19,7 +19,7 @@ Commands:
   - Command: |
         wsb start --config "<Configuration><MappedFolders><MappedFolder><HostFolder>{PATH_ABSOLUTE:folder}</HostFolder><ReadOnly>false</ReadOnly></MappedFolder></MappedFolders></Configuration>"
         wsb exec -r System --id YOUR_ID -c "cmd.exe /c copy C:\users\WDAGUtilityAccount\Desktop\Temp\{PATH} {PATH}"
-    Description: 'Allows the specified folder to be accessible from within the Windows Sandbox, mounted at `C:\users\WDAGUtilityAccount\Desktop` with the same folder name as the source folder. This allows, for example, for copying payloads from the host system into the sandbox, copying payloads from the sandbox back to the host system, or for accessing arbitrary host system files by the sandbox.'
+    Description: 'Allows the specified folder to be accessible from within the Windows Sandbox, mounted under `C:\users\WDAGUtilityAccount\Desktop` with the same folder name as the source folder. This allows, for example, for copying payloads from the host system into the sandbox (seen here), copying payloads from the sandbox back to the host system, or for accessing arbitrary host system files by the sandbox.'
     Usecase: Fileless execution of arbitrary commands in an EDR-free environment, with access to files on the host system, while the host-side process tree is masked by the Sandbox client binaries.
     Category: Execute
     Privileges: User

--- a/yml/OtherMSBinaries/Wsb.yml
+++ b/yml/OtherMSBinaries/Wsb.yml
@@ -4,7 +4,9 @@ Description: Windows Sandbox command-line interface. Creates, lists, controls, a
 Author: Konrad 'unrooted' Klawikowski
 Created: 2026-05-28
 Commands:
-  - Command: wsb start --config "<Configuration><LogonCommand><Command>{CMD}</Command></LogonCommand></Configuration>"
+  - Command: |
+      wsb start --config "<Configuration><LogonCommand><Command>{CMD}</Command></LogonCommand></Configuration>"
+      wsb exec -r System --id YOUR_ID
     Description: 'Executes the given command in a Windows Sandbox from an inline XML configuration with an embedded `<LogonCommand>`, leaving no `.wsb` file on disk. Note: `<LogonCommand>` only fires once `WDAGUtilityAccount` actually logs in, which only happens after an RDP session is established via `wsb connect`, so this pattern opens a visible Sandbox window.'
     Usecase: Fileless execution of arbitrary commands in an EDR-free environment whose host-side process tree is masked by the Sandbox client binaries.
     Category: Execute
@@ -14,28 +16,27 @@ Commands:
     Tags:
       - Execute: CMD
 
-  - Command: wsb start --config "<Configuration><MappedFolders><MappedFolder><HostFolder>{HOST_PATH}</HostFolder><ReadOnly>false</ReadOnly></MappedFolder></MappedFolders><LogonCommand><Command>cmd.exe /c copy C:\users\WDAGUtilityAccount\Desktop\{folder}\{payload} {HOST_PATH}</Command></LogonCommand></Configuration>"
-    Description: 'Adds an arbitrary read-write host-folder mapping to the inline XML, then uses the LogonCommand to drop a payload from inside the sandbox back onto that host path. Same logon-trigger caveat as the previous entry: `wsb connect` (visible window) is required to fire the LogonCommand. The resulting host-side file-creation event is attributed to the Hyper-V worker (vmwp.exe) - not to wsb.exe or the calling binary - so EDR rules keyed on the writing process miss the cross-boundary write entirely.'
-    Usecase: Drop a payload to an arbitrary host filesystem location with the file-creation event's parent process chain obscured behind WindowsSandbox* binaries
+  - Command: |
+        wsb start --config "<Configuration><MappedFolders><MappedFolder><HostFolder>{PATH_ABSOLUTE:folder}</HostFolder><ReadOnly>false</ReadOnly></MappedFolder></MappedFolders></Configuration>"
+        wsb exec -r System --id YOUR_ID -c "cmd.exe /c copy C:\users\WDAGUtilityAccount\Desktop\Temp\{PATH} {PATH}" 
+    Description: "Allows the specified folder to be accessible from within the Windows Sandbox, mounted at `C:\users\WDAGUtilityAccount\Desktop` with the same folder name as the source folder. This allows, for example, for copying payloads from the host system into the sandbox, copying payloads from the sandbox back to the host system, or for accessing arbitrary host system files by the sandbox."
+    Usecase: Fileless execution of arbitrary commands in an EDR-free environment, with access to files on the host system, while the host-side process tree is masked by the Sandbox client binaries.
     Category: Execute
     Privileges: User
     MitreID: T1564.006
     OperatingSystem: Windows 11 24H2 and later
+    Tags:
+      - Execute: CMD
 
-  - Command: wsb exec --id {sandbox_id} -c {payload.exe} -r System
-    Description: 'Executes a command inside an already-running Windows Sandbox in the SYSTEM context. Unlike -r ExistingLogin, -r System does NOT require an active user session, so no `wsb connect` is needed - this is the truly headless variant of the abuse pattern. Pairing this with a prior `wsb start` (without a LogonCommand) splits the CLI-argument surface across two distinct wsb.exe invocations, so detection rules that look for `--config` with embedded `<LogonCommand>` miss the combined pattern; correlation across calls (joined on sandbox-id GUID) is required.'
-    Usecase: Execute SYSTEM-context commands inside a sandbox that is already running, separating environment setup from payload delivery
+  - Command: |
+      wsb start
+      wsb share --id YOUR_ID -f {PATH_ABSOLUTE:folder} -s c:\SOME_FOLDER --allow-write
+      wsb exec -r System --id YOUR_ID -c "cmd.exe /c copy {PATH_ABSOLUTE} c:\SOME_FOLDER"       
+    Description: 'Allows the specified folder to be accessible from within the Windows Sandbox, mounted at `c:\SOME_FOLDER`. This allows, for example, for copying payloads from the host system into the sandbox, copying payloads from the sandbox back to the host system (seen here), or for accessing arbitrary host system files by the sandbox.'
+    Usecase: Fileless execution of arbitrary commands in an EDR-free environment, with access to files on the host system, while the host-side process tree is masked by the Sandbox client binaries.
     Category: Execute
     Privileges: User
-    MitreID: T1218
-    OperatingSystem: Windows 11 24H2 and later
-
-  - Command: wsb share --id {sandbox_id} -f {HOST_PATH} -s C:\mount --allow-write
-    Description: 'Shares a host folder into a running Windows Sandbox at runtime, with --allow-write granting sandbox-to-host writes. Before the wsb.exe CLI shipped in 24H2, mapped folders could only be declared statically in the .wsb at boot time; this subcommand lets a process that has already started a sandbox dynamically grant read-write access to additional host paths post-boot, without restarting or writing a configuration file. Detection rules that scan `wsb start` configs for read-write MappedFolder blocks miss this entirely.'
-    Usecase: Dynamically extend a running sandbox's read-write host filesystem access mid-session, post-boot
-    Category: Copy
-    Privileges: User
-    MitreID: T1105
+    MitreID: T1564.006
     OperatingSystem: Windows 11 24H2 and later
 
 Full_Path:
@@ -48,7 +49,6 @@ Detection:
   - IOC: wsb.exe command line containing --config with an embedded <LogonCommand> XML element
   - IOC: wsb.exe command line invoking the share subcommand with --allow-write
   - IOC: wsb.exe command line invoking the exec subcommand with -r System
-  - IOC: Correlated pair - wsb.exe start followed by wsb.exe exec/share/connect against the same sandbox ID within a short window
   - IOC: WindowsSandboxServer.exe spawns whenever a Sandbox session starts, regardless of whether anyone connects. Lives under %ProgramFiles%\WindowsApps\MicrosoftWindows.WindowsSandbox_*\.
   - IOC: WindowsSandboxRemoteSession.exe spawns ONLY when an RDP connection to the Sandbox is established - opening a .wsb file directly auto-connects (so both processes appear), but `wsb start` alone does NOT spawn it. Its absence while WindowsSandboxServer.exe is alive means no user has connected.
   - IOC: (highest-signal for headless abuse) WindowsSandboxServer.exe present WITHOUT WindowsSandboxRemoteSession.exe indicates a Sandbox VM is running with no interactive session. Legitimate usage almost always involves an RDP connection (because users want to use the Sandbox); a server-without-remote-session state is consistent with the `wsb exec -r System` headless attack primitive.
@@ -63,3 +63,5 @@ Resources:
 
 Acknowledgement:
   - Person: Konrad 'unrooted' Klawikowski
+  - Person: Lloyd Davies
+    Twitter: '@LloydLabs'


### PR DESCRIPTION
Added: 
* entry for wsb.exe under `yml\OtherMSBinaries\wsb.yml`
* actually, couple of sample commands for it 

More details:
* new wsb.exe cli for interacting with Windows Sandbox can be abused - hence adding it
* it allows the attackers for fileless configuration with host-filesystem writes (it's a feature, not a bug), which seems like a nice addition to the LOLBAS project, as no way that's gonna be changed if it was designed this way
* added a simple PoC of the abuse on my GitHub Gist - referenced it in the file itself (benign, spawns marker.txt on the host system)
* added a couple of IOCs which can be correlated when this could be abused (no idea how common it'd be tho.)