### PR TITLE
fix: improve validation error handling

### DIFF
--- a/.github/workflows/validation.py
+++ b/.github/workflows/validation.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
                     has_errors = True
             except Exception as e:
                 print(f"⚠️ Error processing {file_path}: {e}\n")
-                print(f"::error file={file_path},line=1,title=Processing error::Error processing file: {escaper(e)}")
+                print(f"::error file={file_path},line=1,title=Processing error::Error processing file: {escaper(str(e))}")
                 has_errors = True
 
-    sys.exit(-1 if has_errors else 0)
+    sys.exit(1 if has_errors else 0)


### PR DESCRIPTION
This PR fixes two validation reliability issues in `.github/workflows/validation.py`.

### Fix 1: Exception handling in processing errors

The processing error handler called:

```python
escaper(e)
```

where `e` is an `Exception` object.

Since `escaper()` expects a string and internally uses `.replace()`, the error-reporting path can itself raise an exception when handling malformed YAML or other processing failures.

This PR converts the exception to a string before escaping:

```python
escaper(str(e))
```

### Fix 2: Standard non-zero exit code

The validator exited with:

```python
sys.exit(-1)
```

on validation failures.

On POSIX systems, negative exit codes are normalized (commonly to `255`), which can be confusing when interpreting CI results.

This PR changes the failure path to:

```python
sys.exit(1)
```

which is the conventional non-zero exit code for general errors.

## Impact

* Prevents failures in the error-reporting path when processing exceptions.
* Improves reliability of GitHub Actions error annotations.
* Uses standard exit-code semantics for validation failures.
* Does not change validation logic or schema behavior.
