### PR TITLE
Add SCP.exe for execute operation 

### DIFF
--- a/yml/OSBinaries/Scp.yml
+++ b/yml/OSBinaries/Scp.yml
@@ -19,4 +19,4 @@ Resources:
   - Link: https://gtfobins.org/gtfobins/scp/
 Acknowledgement:
   - Person: BinFault
-    Handle: @binfault
+    Handle: '@binfault'

--- a/yml/OSBinaries/Scp.yml
+++ b/yml/OSBinaries/Scp.yml
@@ -1,0 +1,22 @@
+---
+Name: scp.exe
+Description: Used for uploading or downloading files over ssh server.
+Author: BinFault
+Created: 2026-06-03
+Commands:
+  - Command: scp.exe -o ProxyCommand="{CMD}" {RANDOM_LOCAL_FILE_PATH} localhost:~/
+    Description: Executes specified command from scp.exe
+    Usecase: Performs execution of specified file, can be used as a defensive evasion.
+    Category: Execute
+    Privileges: User
+    MitreID: T1202
+    OperatingSystem: Windows 10, Windows 11
+Full_Path:
+  - Path: C:\Windows\System32\OpenSSH\scp.exe
+Detection:
+  - IOC: Command line arguments specifying execution.
+Resources:
+  - Link: https://gtfobins.org/gtfobins/scp/
+Acknowledgement:
+  - Person: BinFault
+    Handle: @binfault

--- a/yml/OSBinaries/Scp.yml
+++ b/yml/OSBinaries/Scp.yml
@@ -1,20 +1,22 @@
 ---
 Name: scp.exe
-Description: Used for uploading or downloading files over ssh server.
+Description: Used for uploading or downloading files over SSH.
 Author: BinFault
 Created: 2026-06-03
 Commands:
-  - Command: scp.exe -o ProxyCommand="{CMD}" {RANDOM_LOCAL_FILE_PATH} localhost:~/
-    Description: Executes specified command from scp.exe
-    Usecase: Performs execution of specified file, can be used as a defensive evasion.
+  - Command: scp.exe -o ProxyCommand="{CMD}" . localhost:.
+    Description: Spawns specified command from `svchost.exe` -> `sihost.exe`, even if no SSH server is running from localhost (or any other address specified).
+    Usecase: Proxy execution of specified command, can be used as a defensive evasion.
     Category: Execute
     Privileges: User
     MitreID: T1202
     OperatingSystem: Windows 10, Windows 11
+    Tags:
+      - Execute: CMD
 Full_Path:
   - Path: C:\Windows\System32\OpenSSH\scp.exe
 Detection:
-  - IOC: Command line arguments specifying execution.
+  - IOC: `scp.exe` executions referencing `ProxyCommand`.c
 Resources:
   - Link: https://gtfobins.org/gtfobins/scp/
 Acknowledgement:

--- a/yml/OSBinaries/Scp.yml
+++ b/yml/OSBinaries/Scp.yml
@@ -16,7 +16,7 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\OpenSSH\scp.exe
 Detection:
-  - IOC: `scp.exe` executions referencing `ProxyCommand`.c
+  - IOC: "`scp.exe` executions referencing `ProxyCommand`."
 Resources:
   - Link: https://gtfobins.org/gtfobins/scp/
 Acknowledgement:


### PR DESCRIPTION
SCP can be used for proxying malware execution.

You can try executing below command for testing purpose

scp.exe -o ProxyCommand="cmd.exe /c calc.exe" / localhost:~/