### PR TITLE
Add SystemSettingsAdminFlows.exe

### DIFF
--- a/yml/OSBinaries/SystemSettingsAdminFlows.yml
+++ b/yml/OSBinaries/SystemSettingsAdminFlows.yml
@@ -1,0 +1,51 @@
+---
+Name: SystemSettingsAdminFlows.exe
+Description: Windows Settings administrative flows utility, used by the Settings app to apply system configuration changes that require elevation
+Author: Ashish Pulivarthy
+Created: 2026-08-06
+Commands:
+  - Command: SystemSettingsAdminFlows.exe Defender RTP 1
+    Description: Disables Microsoft Defender Real-Time Protection
+    Usecase: Disable endpoint protection prior to deploying additional tooling or ransomware
+    Category: Tamper
+    Privileges: Admin
+    MitreID: T1562.001
+    OperatingSystem: Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022
+  - Command: SystemSettingsAdminFlows.exe Defender SpynetReporting 0
+    Description: Disables Microsoft Defender cloud-delivered protection (MAPS/SpyNet reporting)
+    Usecase: Reduce detection efficacy by severing cloud-based protection
+    Category: Tamper
+    Privileges: Admin
+    MitreID: T1562.001
+    OperatingSystem: Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022
+  - Command: SystemSettingsAdminFlows.exe Defender SubmitSamplesConsent 0
+    Description: Disables automatic sample submission to Microsoft
+    Usecase: Prevent suspicious files from being submitted for analysis
+    Category: Tamper
+    Privileges: Admin
+    MitreID: T1562.001
+    OperatingSystem: Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022
+  - Command: SystemSettingsAdminFlows.exe Defender DisableEnhancedNotifications 1
+    Description: Disables Microsoft Defender enhanced notifications
+    Usecase: Suppress alerts that would otherwise surface malicious activity to the user
+    Category: Tamper
+    Privileges: Admin
+    MitreID: T1562.001
+    OperatingSystem: Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022
+Full_Path:
+  - Path: C:\Windows\System32\SystemSettingsAdminFlows.exe
+Code_Sample:
+  - Code:
+Detection:
+  - IOC: SystemSettingsAdminFlows.exe executed with a "Defender" argument
+  - IOC: SystemSettingsAdminFlows.exe with a parent process other than SystemSettings.exe or the Settings app
+  - IOC: Microsoft-Windows-Windows Defender/Operational Event ID 5007 recording a configuration change
+  - IOC: Sysmon Event ID 1 / Security Event ID 4688 process creation for SystemSettingsAdminFlows.exe
+  - Analysis: https://www.huntress.com/blog/lolbin-to-inc-ransomware
+  - Sigma: https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_systemsettingsadminflows_defender_disable/
+Resources:
+  - Link: https://www.huntress.com/blog/lolbin-to-inc-ransomware
+  - Link: https://thedfirreport.com/2026/02/23/apache-activemq-exploit-leads-to-lockbit-ransomware/
+Acknowledgement:
+  - Person: Harlan Carvey
+    Handle: '@keydet89'

--- a/yml/OSBinaries/SystemSettingsAdminFlows.yml
+++ b/yml/OSBinaries/SystemSettingsAdminFlows.yml
@@ -35,12 +35,12 @@ Commands:
 Full_Path:
   - Path: C:\Windows\System32\SystemSettingsAdminFlows.exe
 Detection:
+  - Sigma: https://github.com/SigmaHQ/sigma/blob/8eaafff1f2845a696050e05e72ba1140ee190698/rules/windows/process_creation/proc_creation_win_systemsettingsadminflows_defender_disable.yml
+  - Analysis: https://www.huntress.com/blog/lolbin-to-inc-ransomware
   - IOC: SystemSettingsAdminFlows.exe executed with a "Defender" argument
   - IOC: SystemSettingsAdminFlows.exe with a parent process other than SystemSettings.exe or the Settings app
   - IOC: Microsoft-Windows-Windows Defender/Operational Event ID 5007 recording a configuration change
   - IOC: Sysmon Event ID 1 / Security Event ID 4688 process creation for SystemSettingsAdminFlows.exe
-  - Analysis: https://www.huntress.com/blog/lolbin-to-inc-ransomware
-  - Sigma: https://detection.fyi/sigmahq/sigma/windows/process_creation/proc_creation_win_systemsettingsadminflows_defender_disable/
 Resources:
   - Link: https://www.huntress.com/blog/lolbin-to-inc-ransomware
   - Link: https://thedfirreport.com/2026/02/23/apache-activemq-exploit-leads-to-lockbit-ransomware/

--- a/yml/OSBinaries/SystemSettingsAdminFlows.yml
+++ b/yml/OSBinaries/SystemSettingsAdminFlows.yml
@@ -34,8 +34,6 @@ Commands:
     OperatingSystem: Windows 10, Windows 11, Windows Server 2016, Windows Server 2019, Windows Server 2022
 Full_Path:
   - Path: C:\Windows\System32\SystemSettingsAdminFlows.exe
-Code_Sample:
-  - Code:
 Detection:
   - IOC: SystemSettingsAdminFlows.exe executed with a "Defender" argument
   - IOC: SystemSettingsAdminFlows.exe with a parent process other than SystemSettings.exe or the Settings app


### PR DESCRIPTION
Adds an OSBinaries entry for SystemSettingsAdminFlows.exe, the Settings app's
elevation helper, documenting four Defender configuration flows that are
invokable directly from the command line.

**On the criteria.** The unexpected functionality here isn't that the binary
changes Defender settings — it's that those flows are reachable as command-line
arguments from any elevated process, entirely outside the Settings UI and its
confirmation path. Notably, this route touches neither Set-MpPreference nor a
direct registry write, which is where most existing Defender-tamper detections
are anchored. Categorised as Tamper per CategoryList.md, mapped to T1562.001.

**Observed in the wild by two independent reporters:**
- Huntress — INC ransomware: https://www.huntress.com/blog/lolbin-to-inc-ransomware
- The DFIR Report — LockBit via CVE-2023-46604, used on an Exchange server:
  https://thedfirreport.com/2026/02/23/apache-activemq-exploit-leads-to-lockbit-ransomware/

**Detection.** Process-creation and Defender Operational IOCs, plus the SigmaHQ
rule written for this technique (da92713f-ca2d-4fab-8320-098013d3f43a), which
cites the same two sources.

The entry covers the four arguments reported in those two intrusions. The Sigma
rule additionally matches `RealTimeProtection` and `DisableCDPUserAuthPolicy` —
happy to fold those in if you'd prefer fuller coverage.

Passes validation.py and .yamllint locally. First submission, so please tell me
what to fix.